### PR TITLE
Add custom field support to plnk-core and plnk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,48 @@ Real-world wire format differences worth knowing when contributing:
 - Position values are powers of 2 starting at `65536`.
 - `GET /api/boards/{id}` returns a nested `included` object with lists, cards, tasks, labels, memberships, and users.
 
+### Custom fields
+
+All verified against a live server on 2026-08-10. Several contradict Planka's published
+OpenAPI spec — believe this list, not the spec.
+
+- **Values are addressed by a composite path segment**, not ordinary path params:
+  `/api/cards/{c}/custom-field-values/customFieldGroupId:{g}:customFieldId:{f}`
+- **The published spec writes `customFieldId:${customFieldId}` with a literal `$`.** That is a
+  documentation bug. Sending the `$` returns `400 E_MISSING_OR_INVALID_PARAMS` — the server
+  reads it as part of the id and fails a length check.
+- **The published spec spells the DELETE route singular (`custom-field-value`). The live route
+  is plural**, same as PATCH. The singular path returns a bare `{"code":"E_NOT_FOUND"}` with no
+  message — Sails for "no such route" — as opposed to the plural route's
+  `{"code":"E_NOT_FOUND","message":"Custom field value not found"}`.
+- **`content` is capped at 512 characters.** 512 returns `200`, 513 returns `400`. Validate
+  client-side so callers get exit `2` instead of a server `400`.
+- **An empty string is rejected.** `PATCH {"content": ""}` returns `400 … Cannot use ''
+  (empty string) for a required input`. Clearing a value must use DELETE, never a PATCH to
+  empty.
+- **DELETE returns the deleted value** in an `item` envelope, not `204`.
+- **The server may rewrite a card group's `position`.** A create sent `65536` came back as
+  `81920` because a sibling already held the slot. Never assert the echo.
+- **There is no endpoint that filters cards by custom field value.** Filtering is client-side
+  over a snapshot. Do not invent a query parameter for it.
+- **There is no `GET /api/base-custom-field-groups/{id}`.** That path falls through to the SPA
+  and returns HTML with `200` — worse than a 404, because a JSON client fails with a confusing
+  parse error. `PATCH` and `DELETE` on the same prefix *do* exist. Base groups are readable
+  only through `GET /api/projects` or `GET /api/projects/{id}`, under
+  `included.baseCustomFieldGroups`.
+- **A base group's fields are not in the board snapshot.** `GET /api/boards/{id}` →
+  `included.customFields` carries only board- and card-level group fields. Base group fields
+  appear only under the projects endpoints.
+- **A card group adopted from a base group has `name: null` and no fields of its own.**
+  The display name lives on the base group via `baseCustomFieldGroupId`, and
+  `GET /api/custom-field-groups/{adoptedId}` returns `included.customFields: []`. Any
+  name-based resolution must fall back through the base group for *both*, or it will match
+  nothing for every template-adopted group — which is the common case.
+- **`POST /api/projects/{id}/base-custom-field-groups` accepts `position` but omits it from the
+  response.** The base-group model must not require the field.
+- **`showOnFrontOfCard` is honoured on create** and is what makes a value visible on the card
+  face in the web UI. Planka defaults it to `false`.
+
 ## Project Management
 
 Task tracking lives in a Planka instance on the `planka-cli` project. Board and list names are not fixed — inspect actual state before acting. Do not assume milestone boards or canonical columns (`Backlog`, `In Progress`, etc.) exist.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Custom field support across `plnk-core` and `plnk`, adding three resources:
+  - `plnk field-group` — base groups on a project (reusable templates), plus board- and card-level groups. Adopt a template onto a card with `field-group create --card <id> --base <baseGroupId>`.
+  - `plnk field` — the named slots inside a group, with `--show-on-front` controlling visibility on the card face in the Planka web UI.
+  - `plnk card field` — get, set, and clear the values a card stores, with ID-or-name resolution for `--group` and `--field` following the house three-tier match.
+  - `plnk-core` gains `CustomFieldGroupApi`, `CustomFieldApi` and `CardCustomFieldApi`, plus the `BaseCustomFieldGroup`, `CustomFieldGroup`, `CustomField` and `CustomFieldValue` models.
+  - Hidden plural aliases `field-groups` and `fields`, matching the existing `labels` / `boards` pattern.
+  - Values are validated client-side: empty values and values over Planka's 512-character cap exit `2` without issuing a request. Clearing is idempotent — clearing an already-unset value exits `0`.
+  - Name resolution reaches through the base group. A card group adopted from a template has `name: null` and carries no fields of its own, so both the group name and its field names are resolved via `baseCustomFieldGroupId`.
+  - Docs: [Custom fields](docs/cli/custom-fields.md), plus a worked example in `docs/cli/examples.md` and the verified wire quirks in `AGENTS.md`.
+
 ## [0.2.0] - 2026-05-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Reference docs, one per resource:
 - [Projects](docs/cli/projects.md) · [Boards](docs/cli/boards.md) · [Lists](docs/cli/lists.md) · [Cards](docs/cli/cards.md)
 - [Tasks](docs/cli/tasks.md) · [Comments](docs/cli/comments.md) · [Labels](docs/cli/labels.md)
 - [Attachments](docs/cli/attachments.md) · [Memberships](docs/cli/memberships.md) · [Users](docs/cli/users.md)
+- [Custom fields](docs/cli/custom-fields.md)
 - [Authentication](docs/cli/auth.md) · [Grammar reference](docs/cli/grammar.md) · [Transport policy](docs/cli/transport.md)
 - [Worked examples](docs/cli/examples.md)
 

--- a/crates/plnk-cli/src/app.rs
+++ b/crates/plnk-cli/src/app.rs
@@ -569,6 +569,8 @@ pub enum CardAction {
     },
     /// Manage labels on a card
     Label(CardLabelCommand),
+    /// Manage custom field values on a card
+    Field(CardFieldCommand),
     /// Manage assignees on a card
     Assignee(CardAssigneeCommand),
 }
@@ -601,6 +603,51 @@ pub enum CardLabelAction {
         card: String,
         /// Label ID
         label: String,
+    },
+}
+
+// ── Card Field ──────────────────────────────────────────────────────────
+
+/// Custom field *values* on a card — the string a card stores for one
+/// (group, field) pair.
+#[derive(Parser)]
+pub struct CardFieldCommand {
+    #[command(subcommand)]
+    pub action: CardFieldAction,
+}
+
+#[derive(Subcommand)]
+pub enum CardFieldAction {
+    /// List custom field values on a card
+    List {
+        /// Card ID
+        card: String,
+    },
+    /// Set a custom field value on a card
+    Set {
+        /// Card ID
+        card: String,
+        /// Custom field group ID or name; use an ID to avoid ambiguity
+        #[arg(long)]
+        group: String,
+        /// Custom field ID or name; use an ID to avoid ambiguity
+        #[arg(long)]
+        field: String,
+        /// Value to store. Capped at 512 characters. An empty value is not
+        /// accepted — use `plnk card field clear` to remove a value
+        #[arg(long)]
+        value: String,
+    },
+    /// Clear a custom field value on a card
+    Clear {
+        /// Card ID
+        card: String,
+        /// Custom field group ID or name; use an ID to avoid ambiguity
+        #[arg(long)]
+        group: String,
+        /// Custom field ID or name; use an ID to avoid ambiguity
+        #[arg(long)]
+        field: String,
     },
 }
 

--- a/crates/plnk-cli/src/app.rs
+++ b/crates/plnk-cli/src/app.rs
@@ -104,6 +104,8 @@ pub enum Command {
     Comment(CommentCommand),
     /// Manage board labels
     Label(LabelCommand),
+    /// Manage custom field groups
+    FieldGroup(FieldGroupCommand),
     /// Manage attachments on cards
     Attachment(AttachmentCommand),
     /// Manage project/board memberships
@@ -158,6 +160,19 @@ pub enum Command {
         /// Parent board ID
         #[arg(long)]
         board: String,
+    },
+    /// Alias for `field-group list --project|--board|--card <id>`
+    #[command(hide = true)]
+    FieldGroups {
+        /// Parent project ID (lists base groups)
+        #[arg(long, group = "scope")]
+        project: Option<String>,
+        /// Parent board ID
+        #[arg(long, group = "scope")]
+        board: Option<String>,
+        /// Parent card ID
+        #[arg(long, group = "scope")]
+        card: Option<String>,
     },
 }
 
@@ -749,6 +764,87 @@ pub enum LabelAction {
     /// Delete a label
     Delete {
         /// Label ID
+        id: String,
+    },
+}
+
+// ── Field Group ─────────────────────────────────────────────────────────
+
+/// Custom field groups hold the named fields a card can carry values for.
+///
+/// A group on a *project* is a reusable template (a base group). A card adopts
+/// a template with `create --card <id> --base <baseGroupId>`, or defines a
+/// one-off group with `create --card <id> --name <name>`.
+#[derive(Parser)]
+pub struct FieldGroupCommand {
+    #[command(subcommand)]
+    pub action: FieldGroupAction,
+}
+
+#[derive(Subcommand)]
+pub enum FieldGroupAction {
+    /// List custom field groups in a project, board, or card
+    List {
+        /// Parent project ID (lists base groups — the reusable templates)
+        #[arg(long, group = "scope")]
+        project: Option<String>,
+        /// Parent board ID
+        #[arg(long, group = "scope")]
+        board: Option<String>,
+        /// Parent card ID
+        #[arg(long, group = "scope")]
+        card: Option<String>,
+    },
+    /// Find custom field groups by name within a project, board, or card
+    Find {
+        /// Search a project's base groups
+        #[arg(long, group = "scope")]
+        project: Option<String>,
+        /// Search a board's groups
+        #[arg(long, group = "scope")]
+        board: Option<String>,
+        /// Search a card's groups
+        #[arg(long, group = "scope")]
+        card: Option<String>,
+        /// Group name to search for
+        #[arg(long)]
+        name: String,
+    },
+    /// Get a custom field group by ID
+    Get {
+        /// Custom field group ID (base group IDs are accepted too)
+        id: String,
+    },
+    /// Create a custom field group
+    Create {
+        /// Parent project ID — creates a reusable base group
+        #[arg(long, group = "scope")]
+        project: Option<String>,
+        /// Parent board ID
+        #[arg(long, group = "scope")]
+        board: Option<String>,
+        /// Parent card ID
+        #[arg(long, group = "scope")]
+        card: Option<String>,
+        /// Group name. Required for --project and --board; on --card it creates
+        /// a one-off group instead of adopting a template
+        #[arg(long)]
+        name: Option<String>,
+        /// Base group ID to adopt onto a card. Only valid with --card
+        #[arg(long, conflicts_with = "name")]
+        base: Option<String>,
+    },
+    /// Update a custom field group
+    Update {
+        /// Custom field group ID (base group IDs are accepted too)
+        id: String,
+        /// New group name
+        #[arg(long)]
+        name: Option<String>,
+    },
+    /// Delete a custom field group
+    Delete {
+        /// Custom field group ID (base group IDs are accepted too)
         id: String,
     },
 }

--- a/crates/plnk-cli/src/app.rs
+++ b/crates/plnk-cli/src/app.rs
@@ -106,6 +106,8 @@ pub enum Command {
     Label(LabelCommand),
     /// Manage custom field groups
     FieldGroup(FieldGroupCommand),
+    /// Manage custom fields inside a group
+    Field(FieldCommand),
     /// Manage attachments on cards
     Attachment(AttachmentCommand),
     /// Manage project/board memberships
@@ -160,6 +162,16 @@ pub enum Command {
         /// Parent board ID
         #[arg(long)]
         board: String,
+    },
+    /// Alias for `field list --group|--base-group <id>`
+    #[command(hide = true)]
+    Fields {
+        /// Parent custom field group ID
+        #[arg(long, group = "field_scope")]
+        group: Option<String>,
+        /// Parent base custom field group ID
+        #[arg(long = "base-group", group = "field_scope")]
+        base_group: Option<String>,
     },
     /// Alias for `field-group list --project|--board|--card <id>`
     #[command(hide = true)]
@@ -845,6 +857,76 @@ pub enum FieldGroupAction {
     /// Delete a custom field group
     Delete {
         /// Custom field group ID (base group IDs are accepted too)
+        id: String,
+    },
+}
+
+// ── Field ───────────────────────────────────────────────────────────────
+
+/// Custom fields are the named slots inside a group. A card carries a *value*
+/// for a field; see `plnk card field`.
+#[derive(Parser)]
+pub struct FieldCommand {
+    #[command(subcommand)]
+    pub action: FieldAction,
+}
+
+#[derive(Subcommand)]
+pub enum FieldAction {
+    /// List custom fields in a group
+    List {
+        /// Parent custom field group ID
+        #[arg(long, group = "field_scope")]
+        group: Option<String>,
+        /// Parent base custom field group ID
+        #[arg(long = "base-group", group = "field_scope")]
+        base_group: Option<String>,
+    },
+    /// Find custom fields by name within a group
+    Find {
+        /// Parent custom field group ID
+        #[arg(long, group = "field_scope")]
+        group: Option<String>,
+        /// Parent base custom field group ID
+        #[arg(long = "base-group", group = "field_scope")]
+        base_group: Option<String>,
+        /// Field name to search for
+        #[arg(long)]
+        name: String,
+    },
+    /// Create a custom field
+    Create {
+        /// Parent custom field group ID
+        #[arg(long, group = "field_scope")]
+        group: Option<String>,
+        /// Parent base custom field group ID
+        #[arg(long = "base-group", group = "field_scope")]
+        base_group: Option<String>,
+        /// Field name
+        #[arg(long)]
+        name: String,
+        /// Show this field's value on the front of the card in the Planka web
+        /// UI. Off by default, matching Planka — it is the difference between a
+        /// field a human sees at a glance and one only a script reads
+        #[arg(long = "show-on-front")]
+        show_on_front: bool,
+    },
+    /// Update a custom field
+    Update {
+        /// Custom field ID
+        id: String,
+        /// New field name
+        #[arg(long)]
+        name: Option<String>,
+        /// Whether the value shows on the front of the card in the Planka web
+        /// UI. Takes an explicit true or false, so that leaving it unset and
+        /// setting it false stay distinguishable
+        #[arg(long = "show-on-front")]
+        show_on_front: Option<bool>,
+    },
+    /// Delete a custom field
+    Delete {
+        /// Custom field ID
         id: String,
     },
 }

--- a/crates/plnk-cli/src/commands/card.rs
+++ b/crates/plnk-cli/src/commands/card.rs
@@ -370,8 +370,10 @@ pub async fn execute(
             render_message("Card deleted.", format)?;
         }
         // Label and Assignee subcommands are dispatched in main.rs
-        crate::app::CardAction::Label(_) | crate::app::CardAction::Assignee(_) => {
-            unreachable!("card label/assignee dispatched in main.rs")
+        crate::app::CardAction::Label(_)
+        | crate::app::CardAction::Assignee(_)
+        | crate::app::CardAction::Field(_) => {
+            unreachable!("card label/assignee/field dispatched in main.rs")
         }
     }
     Ok(())

--- a/crates/plnk-cli/src/commands/card_field.rs
+++ b/crates/plnk-cli/src/commands/card_field.rs
@@ -1,0 +1,240 @@
+use plnk_core::api::{CardCustomFieldApi, CustomFieldApi, CustomFieldGroupApi, match_by_name};
+use plnk_core::error::PlankaError;
+use plnk_core::models::{
+    BaseCustomFieldGroup, CUSTOM_FIELD_VALUE_MAX_LEN, CustomField, CustomFieldGroup,
+};
+
+use crate::app::OutputFormat;
+use crate::output::{render_collection, render_item, render_message};
+
+/// A card's group paired with the display name it actually presents.
+///
+/// A group adopted from a base group has `name: None` — its display name lives
+/// on the base group, reached through `base_custom_field_group_id`. Matching on
+/// a card group's own `name` alone therefore matches *nothing* for every
+/// template-adopted group, which is the common case.
+struct NamedGroup {
+    group: CustomFieldGroup,
+    display_name: String,
+}
+
+impl plnk_core::api::Named for NamedGroup {
+    fn name(&self) -> &str {
+        &self.display_name
+    }
+}
+
+fn ambiguous(flag: &str, query: &str, candidates: &[(String, String)]) -> PlankaError {
+    let listed = candidates
+        .iter()
+        .map(|(name, id)| {
+            let shown = if name.is_empty() { "<unnamed>" } else { name };
+            format!("{shown} ({id})")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    PlankaError::InvalidOptionValue {
+        field: flag.to_string(),
+        message: format!(
+            "'{query}' matched multiple entries. Be more specific or pass an ID. \
+             Matches: {listed}"
+        ),
+    }
+}
+
+/// Pair each of the card's groups with its effective display name, falling back
+/// through the base group when the card group's own name is null.
+async fn named_groups(
+    client: &impl CustomFieldGroupApi,
+    card_id: &str,
+) -> Result<Vec<NamedGroup>, PlankaError> {
+    let groups = client.list_field_groups_for_card(card_id).await?;
+
+    // Only pay for the base-group lookup when some group actually needs it.
+    let needs_base = groups
+        .iter()
+        .any(|group| group.name.is_none() && group.base_custom_field_group_id.is_some());
+    let base_groups: Vec<BaseCustomFieldGroup> = if needs_base {
+        client.list_all_base_field_groups().await?
+    } else {
+        Vec::new()
+    };
+
+    Ok(groups
+        .into_iter()
+        .map(|group| {
+            let display_name = group.name.clone().unwrap_or_else(|| {
+                group
+                    .base_custom_field_group_id
+                    .as_ref()
+                    .and_then(|base_id| {
+                        base_groups
+                            .iter()
+                            .find(|base| base.id == *base_id)
+                            .map(|base| base.name.clone())
+                    })
+                    .unwrap_or_default()
+            });
+            NamedGroup {
+                group,
+                display_name,
+            }
+        })
+        .collect())
+}
+
+/// Resolve `--group` to a card group. An argument that is already one of the
+/// card's group IDs skips resolution entirely.
+async fn resolve_group(
+    client: &impl CustomFieldGroupApi,
+    card_id: &str,
+    query: &str,
+) -> Result<CustomFieldGroup, PlankaError> {
+    let candidates = named_groups(client, card_id).await?;
+
+    if let Some(found) = candidates.iter().find(|entry| entry.group.id == query) {
+        return Ok(found.group.clone());
+    }
+
+    let matched = match_by_name(&candidates, query);
+    match matched.len() {
+        0 => Err(PlankaError::NotFoundMessage {
+            message: format!(
+                "No custom field group matching '{query}' is attached to this card. \
+                 Use 'plnk field-group list --card {card_id}' to inspect the card's \
+                 groups or pass a group ID."
+            ),
+        }),
+        1 => Ok(matched[0].group.clone()),
+        _ => {
+            let listed = matched
+                .iter()
+                .map(|entry| (entry.display_name.clone(), entry.group.id.clone()))
+                .collect::<Vec<_>>();
+            Err(ambiguous("--group", query, &listed))
+        }
+    }
+}
+
+/// Every field reachable through a group: its own fields plus, for an adopted
+/// group, the base group's fields — which is where an adopted group's fields
+/// actually live.
+async fn fields_for_group(
+    client: &impl CustomFieldApi,
+    group: &CustomFieldGroup,
+) -> Result<Vec<CustomField>, PlankaError> {
+    let mut fields = client.list_fields(&group.id, false).await?;
+
+    if let Some(base_id) = &group.base_custom_field_group_id {
+        for field in client.list_fields(base_id, true).await? {
+            if !fields.iter().any(|existing| existing.id == field.id) {
+                fields.push(field);
+            }
+        }
+    }
+
+    Ok(fields)
+}
+
+async fn resolve_field(
+    client: &impl CustomFieldApi,
+    group: &CustomFieldGroup,
+    query: &str,
+) -> Result<String, PlankaError> {
+    let fields = fields_for_group(client, group).await?;
+
+    if fields.iter().any(|field| field.id == query) {
+        return Ok(query.to_string());
+    }
+
+    let matched = match_by_name(&fields, query);
+    match matched.len() {
+        0 => Err(PlankaError::NotFoundMessage {
+            message: format!(
+                "No custom field matching '{query}' was found in this group. \
+                 Use 'plnk field list --group {}' to inspect its fields or pass \
+                 a field ID.",
+                group.id
+            ),
+        }),
+        1 => Ok(matched[0].id.clone()),
+        _ => {
+            let listed = matched
+                .iter()
+                .map(|field| (field.name.clone(), field.id.clone()))
+                .collect::<Vec<_>>();
+            Err(ambiguous("--field", query, &listed))
+        }
+    }
+}
+
+/// Validate a value before any request is issued.
+///
+/// The server rejects both cases, but a client-side check turns a wasted round
+/// trip and an opaque `400` into a validation error with a clear message.
+fn validate_value(value: &str) -> Result<(), PlankaError> {
+    if value.is_empty() {
+        return Err(PlankaError::InvalidOptionValue {
+            field: "--value".to_string(),
+            message: "A custom field value cannot be empty. Use \
+                      'plnk card field clear' to remove a value."
+                .to_string(),
+        });
+    }
+
+    // Planka counts characters, not bytes. A string of astral-plane characters
+    // may still be rejected server-side, since JavaScript measures UTF-16 code
+    // units; that degrades to the server's own 400 rather than a wrong accept.
+    let length = value.chars().count();
+    if length > CUSTOM_FIELD_VALUE_MAX_LEN {
+        return Err(PlankaError::InvalidOptionValue {
+            field: "--value".to_string(),
+            message: format!(
+                "A custom field value is capped at {CUSTOM_FIELD_VALUE_MAX_LEN} characters, \
+                 got {length}."
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+pub async fn execute(
+    client: &(impl CardCustomFieldApi + CustomFieldGroupApi + CustomFieldApi),
+    action: crate::app::CardFieldAction,
+    format: OutputFormat,
+    full: bool,
+) -> Result<(), PlankaError> {
+    use crate::app::CardFieldAction as Action;
+
+    match action {
+        Action::List { card } => {
+            let values = client.list_field_values(&card).await?;
+            render_collection(&values, format, full)?;
+        }
+        Action::Set {
+            card,
+            group,
+            field,
+            value,
+        } => {
+            // Validate before resolving so a bad value costs no requests at all.
+            validate_value(&value)?;
+            let group = resolve_group(client, &card, &group).await?;
+            let field_id = resolve_field(client, &group, &field).await?;
+            let stored = client
+                .set_field_value(&card, &group.id, &field_id, &value)
+                .await?;
+            render_item(&stored, format, full)?;
+        }
+        Action::Clear { card, group, field } => {
+            let group = resolve_group(client, &card, &group).await?;
+            let field_id = resolve_field(client, &group, &field).await?;
+            client
+                .clear_field_value(&card, &group.id, &field_id)
+                .await?;
+            render_message("Custom field value cleared.", format)?;
+        }
+    }
+    Ok(())
+}

--- a/crates/plnk-cli/src/commands/field.rs
+++ b/crates/plnk-cli/src/commands/field.rs
@@ -1,0 +1,87 @@
+use plnk_core::api::CustomFieldApi;
+use plnk_core::error::PlankaError;
+use plnk_core::models::UpdateCustomField;
+
+use crate::app::OutputFormat;
+use crate::commands::project::confirm_delete;
+use crate::output::{render_collection, render_item, render_message};
+
+/// Resolve the `--group` / `--base-group` pair into a group ID and a flag
+/// saying which kind it is.
+///
+/// The kind cannot be inferred from the ID: base groups and ordinary groups are
+/// separate wire resources reached by different routes, and a base group's
+/// fields are readable only through the projects list.
+fn scope(group: Option<String>, base_group: Option<String>) -> Result<(String, bool), PlankaError> {
+    match (group, base_group) {
+        (Some(id), None) => Ok((id, false)),
+        (None, Some(id)) => Ok((id, true)),
+        _ => Err(PlankaError::MissingRequiredOption {
+            field: "--group or --base-group".to_string(),
+        }),
+    }
+}
+
+pub async fn execute(
+    client: &impl CustomFieldApi,
+    action: crate::app::FieldAction,
+    format: OutputFormat,
+    yes: bool,
+    full: bool,
+) -> Result<(), PlankaError> {
+    use crate::app::FieldAction as Action;
+
+    match action {
+        Action::List { group, base_group } => {
+            let (id, base) = scope(group, base_group)?;
+            let fields = client.list_fields(&id, base).await?;
+            render_collection(&fields, format, full)?;
+        }
+        Action::Find {
+            group,
+            base_group,
+            name,
+        } => {
+            let (id, base) = scope(group, base_group)?;
+            let fields = client.find_fields(&id, base, &name).await?;
+            render_collection(&fields, format, full)?;
+        }
+        Action::Create {
+            group,
+            base_group,
+            name,
+            show_on_front,
+        } => {
+            let (id, base) = scope(group, base_group)?;
+            let field = client.create_field(&id, base, &name, show_on_front).await?;
+            render_item(&field, format, full)?;
+        }
+        Action::Update {
+            id,
+            name,
+            show_on_front,
+        } => {
+            if name.is_none() && show_on_front.is_none() {
+                return Err(PlankaError::InvalidOptionValue {
+                    field: "--name / --show-on-front".to_string(),
+                    message: "At least one field must be provided for update".to_string(),
+                });
+            }
+            let params = UpdateCustomField {
+                name,
+                show_on_front_of_card: show_on_front,
+            };
+            let field = client.update_field(&id, params).await?;
+            render_item(&field, format, full)?;
+        }
+        Action::Delete { id } => {
+            if !yes && !confirm_delete("field", &id) {
+                render_message("Aborted.", format)?;
+                return Ok(());
+            }
+            client.delete_field(&id).await?;
+            render_message("Field deleted.", format)?;
+        }
+    }
+    Ok(())
+}

--- a/crates/plnk-cli/src/commands/field_group.rs
+++ b/crates/plnk-cli/src/commands/field_group.rs
@@ -1,0 +1,230 @@
+use plnk_core::api::{CustomFieldGroupApi, match_by_name};
+use plnk_core::error::PlankaError;
+use plnk_core::models::UpdateCustomFieldGroup;
+
+use crate::app::OutputFormat;
+use crate::commands::project::confirm_delete;
+use crate::output::{render_collection, render_item, render_message};
+
+/// Base groups and ordinary groups are separate wire resources reached by
+/// different routes, and an ID alone does not say which kind it is. `get`,
+/// `update` and `delete` therefore try the ordinary route first and fall back
+/// to the base route on a not-found, so a caller can pass any group ID that
+/// `create` handed them without tracking its kind.
+fn is_not_found(error: &PlankaError) -> bool {
+    matches!(
+        error,
+        PlankaError::Remote404 { .. } | PlankaError::NotFound { .. }
+    )
+}
+
+/// The `--project` / `--board` / `--card` scope shared by `list`, `find` and
+/// `create`. Clap guarantees at most one is set; exactly-one is checked here.
+struct Scope {
+    project: Option<String>,
+    board: Option<String>,
+    card: Option<String>,
+}
+
+fn missing_scope() -> PlankaError {
+    PlankaError::MissingRequiredOption {
+        field: "--project, --board, or --card".to_string(),
+    }
+}
+
+/// A project yields base groups; a board or card yields ordinary groups. These
+/// are different types with different columns and are deliberately not forced
+/// through one shape.
+async fn list(
+    client: &impl CustomFieldGroupApi,
+    scope: Scope,
+    name: Option<&str>,
+    format: OutputFormat,
+    full: bool,
+) -> Result<(), PlankaError> {
+    if let Some(project_id) = scope.project {
+        let groups = client.list_base_field_groups(&project_id).await?;
+        let groups = match name {
+            Some(query) => match_by_name(&groups, query).into_iter().cloned().collect(),
+            None => groups,
+        };
+        render_collection(&groups, format, full)
+    } else if let Some(board_id) = scope.board {
+        let groups = client.list_field_groups_for_board(&board_id).await?;
+        let groups = match name {
+            Some(query) => match_by_name(&groups, query).into_iter().cloned().collect(),
+            None => groups,
+        };
+        render_collection(&groups, format, full)
+    } else if let Some(card_id) = scope.card {
+        let groups = client.list_field_groups_for_card(&card_id).await?;
+        let groups = match name {
+            Some(query) => match_by_name(&groups, query).into_iter().cloned().collect(),
+            None => groups,
+        };
+        render_collection(&groups, format, full)
+    } else {
+        Err(missing_scope())
+    }
+}
+
+async fn create(
+    client: &impl CustomFieldGroupApi,
+    scope: Scope,
+    name: Option<String>,
+    base: Option<String>,
+    format: OutputFormat,
+    full: bool,
+) -> Result<(), PlankaError> {
+    let require_name = |name: Option<String>| {
+        name.ok_or_else(|| PlankaError::MissingRequiredOption {
+            field: "--name".to_string(),
+        })
+    };
+
+    if let Some(project_id) = scope.project {
+        let name = require_name(name)?;
+        let group = client.create_base_field_group(&project_id, &name).await?;
+        render_item(&group, format, full)
+    } else if let Some(board_id) = scope.board {
+        let name = require_name(name)?;
+        let group = client.create_board_field_group(&board_id, &name).await?;
+        render_item(&group, format, full)
+    } else if let Some(card_id) = scope.card {
+        if base.is_none() && name.is_none() {
+            return Err(PlankaError::InvalidOptionValue {
+                field: "--base / --name".to_string(),
+                message: "Pass --base <baseGroupId> to adopt a template, or --name <name> to \
+                          create a one-off group"
+                    .to_string(),
+            });
+        }
+        let group = client
+            .create_card_field_group(&card_id, base.as_deref(), name.as_deref())
+            .await?;
+        render_item(&group, format, full)
+    } else {
+        Err(missing_scope())
+    }
+}
+
+async fn get(
+    client: &impl CustomFieldGroupApi,
+    id: &str,
+    format: OutputFormat,
+    full: bool,
+) -> Result<(), PlankaError> {
+    match client.get_field_group(id).await {
+        Ok(group) => render_item(&group, format, full),
+        Err(error) if is_not_found(&error) => {
+            let base = client.get_base_field_group(id).await.map_err(|_| error)?;
+            render_item(&base, format, full)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn update(
+    client: &impl CustomFieldGroupApi,
+    id: &str,
+    name: Option<String>,
+    format: OutputFormat,
+    full: bool,
+) -> Result<(), PlankaError> {
+    if name.is_none() {
+        return Err(PlankaError::InvalidOptionValue {
+            field: "--name".to_string(),
+            message: "At least one field must be provided for update".to_string(),
+        });
+    }
+    let params = UpdateCustomFieldGroup { name };
+    match client.update_field_group(id, params.clone()).await {
+        Ok(group) => render_item(&group, format, full),
+        Err(error) if is_not_found(&error) => {
+            let base = client
+                .update_base_field_group(id, params)
+                .await
+                .map_err(|_| error)?;
+            render_item(&base, format, full)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn delete(
+    client: &impl CustomFieldGroupApi,
+    id: &str,
+    format: OutputFormat,
+    yes: bool,
+) -> Result<(), PlankaError> {
+    if !yes && !confirm_delete("field group", id) {
+        return render_message("Aborted.", format);
+    }
+    match client.delete_field_group(id).await {
+        Ok(()) => {}
+        Err(error) if is_not_found(&error) => {
+            // The ordinary route made no change, so retrying the base route is safe.
+            client
+                .delete_base_field_group(id)
+                .await
+                .map_err(|_| error)?;
+        }
+        Err(error) => return Err(error),
+    }
+    render_message("Field group deleted.", format)
+}
+
+pub async fn execute(
+    client: &impl CustomFieldGroupApi,
+    action: crate::app::FieldGroupAction,
+    format: OutputFormat,
+    yes: bool,
+    full: bool,
+) -> Result<(), PlankaError> {
+    use crate::app::FieldGroupAction as Action;
+
+    match action {
+        Action::List {
+            project,
+            board,
+            card,
+        } => {
+            let scope = Scope {
+                project,
+                board,
+                card,
+            };
+            list(client, scope, None, format, full).await
+        }
+        Action::Find {
+            project,
+            board,
+            card,
+            name,
+        } => {
+            let scope = Scope {
+                project,
+                board,
+                card,
+            };
+            list(client, scope, Some(&name), format, full).await
+        }
+        Action::Get { id } => get(client, &id, format, full).await,
+        Action::Create {
+            project,
+            board,
+            card,
+            name,
+            base,
+        } => {
+            let scope = Scope {
+                project,
+                board,
+                card,
+            };
+            create(client, scope, name, base, format, full).await
+        }
+        Action::Update { id, name } => update(client, &id, name, format, full).await,
+        Action::Delete { id } => delete(client, &id, format, yes).await,
+    }
+}

--- a/crates/plnk-cli/src/commands/mod.rs
+++ b/crates/plnk-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod board;
 pub mod card;
 pub mod card_assignee;
+pub mod card_field;
 pub mod card_label;
 pub mod comment;
 pub mod field;

--- a/crates/plnk-cli/src/commands/mod.rs
+++ b/crates/plnk-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod card;
 pub mod card_assignee;
 pub mod card_label;
 pub mod comment;
+pub mod field_group;
 pub mod init;
 pub mod label;
 pub mod list;

--- a/crates/plnk-cli/src/commands/mod.rs
+++ b/crates/plnk-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod card;
 pub mod card_assignee;
 pub mod card_label;
 pub mod comment;
+pub mod field;
 pub mod field_group;
 pub mod init;
 pub mod label;

--- a/crates/plnk-cli/src/help.rs
+++ b/crates/plnk-cli/src/help.rs
@@ -411,6 +411,52 @@ fn get_examples(resource: &str, action: &str) -> Vec<String> {
         ("label", "update") => vec!["plnk label update 111 --name 'blocked' --color sunset-orange".into()],
         ("label", "delete") => vec!["plnk label delete 111".into()],
 
+        // Field group
+        ("field-group", "list") => vec![
+            "plnk field-group list --project 123".into(),
+            "plnk field-group list --card 1234".into(),
+        ],
+        ("field-group", "find") => {
+            vec!["plnk field-group find --project 123 --name 'Documentation'".into()]
+        }
+        ("field-group", "get") => vec!["plnk field-group get 777".into()],
+        ("field-group", "create") => vec![
+            "plnk field-group create --project 123 --name 'Documentation'".into(),
+            "plnk field-group create --card 1234 --base 777".into(),
+            "plnk field-group create --card 1234 --name 'Ad-hoc'".into(),
+        ],
+        ("field-group", "update") => vec!["plnk field-group update 777 --name 'Docs'".into()],
+        ("field-group", "delete") => vec!["plnk field-group delete 777".into()],
+
+        // Field
+        ("field", "list") => vec![
+            "plnk field list --base-group 777".into(),
+            "plnk field list --group 888".into(),
+        ],
+        ("field", "find") => vec!["plnk field find --base-group 777 --name 'Spec'".into()],
+        ("field", "create") => vec![
+            "plnk field create --base-group 777 --name 'Specification' --show-on-front".into(),
+            "plnk field create --group 888 --name 'Implementation Plan'".into(),
+        ],
+        ("field", "update") => vec![
+            "plnk field update 999 --name 'Spec'".into(),
+            "plnk field update 999 --show-on-front false".into(),
+        ],
+        ("field", "delete") => vec!["plnk field delete 999".into()],
+
+        // Card field values (nested under `card`, so the action carries the
+        // subcommand — matching how `card label add` is keyed)
+        ("card", "field list") => vec!["plnk card field list 1234".into()],
+        ("card", "field set") => vec![
+            "plnk card field set 1234 --group 'Documentation' --field 'Specification' \
+             --value 'specs/design.html'"
+                .into(),
+            "plnk card field set 1234 --group 888 --field 999 --value 'specs/design.html'".into(),
+        ],
+        ("card", "field clear") => {
+            vec!["plnk card field clear 1234 --group 'Documentation' --field 'Specification'".into()]
+        }
+
         // Attachment
         ("attachment", "list") => vec!["plnk attachment list --card 1234".into()],
         ("attachment", "upload") => vec!["plnk attachment upload --card 1234 ./spec.png".into()],

--- a/crates/plnk-cli/src/main.rs
+++ b/crates/plnk-cli/src/main.rs
@@ -285,6 +285,9 @@ async fn main() {
             &transport_policy,
         ) {
             Ok(client) => match cmd.action {
+                crate::app::CardAction::Field(sub) => {
+                    commands::card_field::execute(&client, sub.action, app.output, app.full).await
+                }
                 crate::app::CardAction::Label(sub) => {
                     commands::card_label::execute(&client, sub.action, app.output, app.full).await
                 }

--- a/crates/plnk-cli/src/main.rs
+++ b/crates/plnk-cli/src/main.rs
@@ -328,6 +328,16 @@ async fn main() {
             }
             Err(e) => Err(e),
         },
+        Command::Field(cmd) => match build_client(
+            app.server.as_deref(),
+            app.token.as_deref(),
+            &transport_policy,
+        ) {
+            Ok(client) => {
+                commands::field::execute(&client, cmd.action, app.output, app.yes, app.full).await
+            }
+            Err(e) => Err(e),
+        },
         Command::FieldGroup(cmd) => match build_client(
             app.server.as_deref(),
             app.token.as_deref(),
@@ -439,6 +449,23 @@ async fn main() {
                 commands::comment::execute(
                     &client,
                     app::CommentAction::List { card },
+                    app.output,
+                    app.yes,
+                    app.full,
+                )
+                .await
+            }
+            Err(e) => Err(e),
+        },
+        Command::Fields { group, base_group } => match build_client(
+            app.server.as_deref(),
+            app.token.as_deref(),
+            &transport_policy,
+        ) {
+            Ok(client) => {
+                commands::field::execute(
+                    &client,
+                    app::FieldAction::List { group, base_group },
                     app.output,
                     app.yes,
                     app.full,

--- a/crates/plnk-cli/src/main.rs
+++ b/crates/plnk-cli/src/main.rs
@@ -328,6 +328,17 @@ async fn main() {
             }
             Err(e) => Err(e),
         },
+        Command::FieldGroup(cmd) => match build_client(
+            app.server.as_deref(),
+            app.token.as_deref(),
+            &transport_policy,
+        ) {
+            Ok(client) => {
+                commands::field_group::execute(&client, cmd.action, app.output, app.yes, app.full)
+                    .await
+            }
+            Err(e) => Err(e),
+        },
         Command::Attachment(cmd) => match build_client(
             app.server.as_deref(),
             app.token.as_deref(),
@@ -428,6 +439,31 @@ async fn main() {
                 commands::comment::execute(
                     &client,
                     app::CommentAction::List { card },
+                    app.output,
+                    app.yes,
+                    app.full,
+                )
+                .await
+            }
+            Err(e) => Err(e),
+        },
+        Command::FieldGroups {
+            project,
+            board,
+            card,
+        } => match build_client(
+            app.server.as_deref(),
+            app.token.as_deref(),
+            &transport_policy,
+        ) {
+            Ok(client) => {
+                commands::field_group::execute(
+                    &client,
+                    app::FieldGroupAction::List {
+                        project,
+                        board,
+                        card,
+                    },
                     app.output,
                     app.yes,
                     app.full,

--- a/crates/plnk-cli/tests/cli_aliases.rs
+++ b/crates/plnk-cli/tests/cli_aliases.rs
@@ -281,7 +281,16 @@ fn aliases_hidden_from_help() {
 
     // In clap's help, commands are listed as "  <name>  <description>"
     // Check that none of the alias names appear as command entries
-    for alias in &["boards", "lists", "cards", "tasks", "comments", "labels"] {
+    for alias in &[
+        "boards",
+        "lists",
+        "cards",
+        "tasks",
+        "comments",
+        "labels",
+        "field-groups",
+        "fields",
+    ] {
         let pattern = format!("  {alias} ");
         assert!(
             !help.contains(&pattern),
@@ -299,6 +308,43 @@ fn boards_alias_missing_project_exits_2() {
         .env("PLANKA_SERVER", "http://127.0.0.1:1")
         .env("PLANKA_TOKEN", "test-api-key")
         .args(["boards"])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+// ─── Custom field aliases ───────────────────────────────────────────
+
+#[test]
+fn field_groups_alias_resolves() {
+    // Validation happens before network, so no server is needed: reaching the
+    // missing-scope error proves the alias resolved to `field-group list`.
+    plnk()
+        .env("PLANKA_SERVER", "http://127.0.0.1:1")
+        .env("PLANKA_TOKEN", "test-api-key")
+        .args(["field-groups"])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn fields_alias_resolves() {
+    plnk()
+        .env("PLANKA_SERVER", "http://127.0.0.1:1")
+        .env("PLANKA_TOKEN", "test-api-key")
+        .args(["fields"])
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn field_groups_alias_rejects_conflicting_scopes() {
+    plnk()
+        .env("PLANKA_SERVER", "http://127.0.0.1:1")
+        .env("PLANKA_TOKEN", "test-api-key")
+        .args(["field-groups", "--project", "1", "--card", "2"])
         .assert()
         .failure()
         .code(2);

--- a/crates/plnk-cli/tests/cli_help.rs
+++ b/crates/plnk-cli/tests/cli_help.rs
@@ -252,6 +252,8 @@ fn machine_help_all_resources() {
         "task",
         "comment",
         "label",
+        "field-group",
+        "field",
         "attachment",
         "membership",
     ];
@@ -290,4 +292,100 @@ fn normal_help_still_works() {
         .stdout(predicate::str::contains("Create a new card"))
         .stdout(predicate::str::contains("--list"))
         .stdout(predicate::str::contains("--title"));
+}
+
+// ─── Machine help: custom field commands ─────────────────────────────
+
+#[test]
+fn machine_help_field_group_create() {
+    let output = plnk()
+        .args(["field-group", "create", "--help", "--output", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["resource"], "field-group");
+    assert_eq!(json["action"], "create");
+
+    let opts = &json["options"];
+    for flag in ["--project", "--board", "--card", "--name", "--base"] {
+        assert!(
+            opts.get(flag).is_some(),
+            "field-group create should expose {flag}"
+        );
+    }
+
+    assert!(
+        !json["examples"].as_array().unwrap().is_empty(),
+        "field-group create should carry examples"
+    );
+}
+
+#[test]
+fn machine_help_field_create_documents_show_on_front() {
+    let output = plnk()
+        .args(["field", "create", "--help", "--output", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["resource"], "field");
+
+    let description = json["options"]["--show-on-front"]["description"]
+        .as_str()
+        .unwrap()
+        .to_lowercase();
+    assert!(
+        description.contains("front of the card"),
+        "--show-on-front must say plainly what it controls, got: {description}"
+    );
+}
+
+/// The value cap and the fact that clearing is a separate command are the two
+/// things a caller most needs from this help text.
+#[test]
+fn machine_help_card_field_set_documents_limits() {
+    let output = plnk()
+        .args(["card", "field", "set", "--help", "--output", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["resource"], "card");
+    assert_eq!(json["action"], "field set");
+
+    let value_help = json["options"]["--value"]["description"].as_str().unwrap();
+    assert!(
+        value_help.contains("512"),
+        "--value help must state the 512 character cap, got: {value_help}"
+    );
+    assert!(
+        value_help.contains("card field clear"),
+        "--value help must point at card field clear, got: {value_help}"
+    );
+
+    assert!(
+        !json["examples"].as_array().unwrap().is_empty(),
+        "card field set should carry examples"
+    );
+}
+
+#[test]
+fn custom_field_help_renders_in_plain_form() {
+    for args in [
+        vec!["field-group", "--help"],
+        vec!["field", "--help"],
+        vec!["card", "field", "--help"],
+    ] {
+        plnk().args(&args).assert().success();
+    }
 }

--- a/crates/plnk-cli/tests/e2e_custom_fields.rs
+++ b/crates/plnk-cli/tests/e2e_custom_fields.rs
@@ -1,0 +1,542 @@
+//! End-to-end tests for `plnk card field`.
+//!
+//! The centrepiece is name resolution through a base group. A card group
+//! adopted from a base group has `name: null`, so matching a card group by its
+//! own name alone matches nothing for every template-adopted group — the common
+//! case. These tests pin that behaviour.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn plnk_with_server(server_uri: &str) -> Command {
+    let mut cmd = Command::cargo_bin("plnk").unwrap();
+    cmd.env("PLANKA_CONFIG", "/tmp/plnk-test-nonexistent/config.toml");
+    cmd.env("PLANKA_SERVER", server_uri);
+    cmd.env("PLANKA_TOKEN", "test-api-key");
+    cmd
+}
+
+/// A card carrying one group adopted from a base group — so its own `name` is
+/// null and its `customFields` are empty, exactly as the live server returns.
+fn card_snapshot() -> serde_json::Value {
+    serde_json::json!({
+        "item": {
+            "id": "card-1",
+            "listId": "list-1",
+            "boardId": "board-1",
+            "name": "A card",
+            "description": null,
+            "position": 65536.0,
+            "isSubscribed": false,
+            "createdAt": "2026-08-10T00:00:00Z",
+            "updatedAt": null
+        },
+        "included": {
+            "taskLists": [],
+            "tasks": [],
+            "cardLabels": [],
+            "cardMemberships": [],
+            "attachments": [],
+            "customFieldGroups": [
+                {
+                    "id": "card-group-1",
+                    "name": null,
+                    "boardId": null,
+                    "cardId": "card-1",
+                    "baseCustomFieldGroupId": "base-1",
+                    "position": 65536.0,
+                    "createdAt": "2026-08-10T00:00:00Z",
+                    "updatedAt": null
+                }
+            ],
+            "customFields": [],
+            "customFieldValues": []
+        }
+    })
+}
+
+/// The projects list — the only endpoint exposing base groups and their fields.
+fn projects_list(extra_fields: &serde_json::Value) -> serde_json::Value {
+    let mut fields = vec![serde_json::json!({
+        "id": "field-1",
+        "name": "Specification",
+        "position": 65536.0,
+        "showOnFrontOfCard": true,
+        "customFieldGroupId": null,
+        "baseCustomFieldGroupId": "base-1",
+        "createdAt": "2026-08-10T00:00:00Z",
+        "updatedAt": null
+    })];
+    if let Some(more) = extra_fields.as_array() {
+        fields.extend(more.iter().cloned());
+    }
+
+    serde_json::json!({
+        "items": [],
+        "included": {
+            "baseCustomFieldGroups": [
+                {
+                    "id": "base-1",
+                    "name": "Documentation",
+                    "projectId": "project-1",
+                    "createdAt": "2026-08-10T00:00:00Z",
+                    "updatedAt": null
+                }
+            ],
+            "customFields": fields
+        }
+    })
+}
+
+/// The adopted group's own snapshot is empty — its fields live on the base
+/// group. This is what makes the base-group fallback necessary for fields too,
+/// not just for the group name.
+fn empty_group_snapshot() -> serde_json::Value {
+    serde_json::json!({
+        "item": {
+            "id": "card-group-1",
+            "name": null,
+            "boardId": null,
+            "cardId": "card-1",
+            "baseCustomFieldGroupId": "base-1",
+            "position": 65536.0,
+            "createdAt": "2026-08-10T00:00:00Z",
+            "updatedAt": null
+        },
+        "included": {"customFields": []}
+    })
+}
+
+fn value_response() -> serde_json::Value {
+    serde_json::json!({
+        "item": {
+            "id": "value-1",
+            "cardId": "card-1",
+            "customFieldGroupId": "card-group-1",
+            "customFieldId": "field-1",
+            "content": "specs/x.html",
+            "createdAt": "2026-08-10T00:00:00Z",
+            "updatedAt": null
+        }
+    })
+}
+
+async fn mount_resolution_fixtures(server: &MockServer, extra_fields: &serde_json::Value) {
+    Mock::given(method("GET"))
+        .and(path("/api/cards/card-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(card_snapshot()))
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/projects"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(projects_list(extra_fields)))
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/custom-field-groups/card-group-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty_group_snapshot()))
+        .mount(server)
+        .await;
+}
+
+/// The single most likely bug in the feature: `--group Documentation` must
+/// match a card group whose own name is null, via its base group.
+#[tokio::test]
+async fn set_resolves_group_name_through_the_base_group() {
+    let server = MockServer::start().await;
+    mount_resolution_fixtures(&server, &serde_json::json!([])).await;
+
+    Mock::given(method("PATCH"))
+        .and(path(
+            "/api/cards/card-1/custom-field-values/customFieldGroupId:card-group-1:customFieldId:field-1",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(value_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    plnk_with_server(&server.uri())
+        .args([
+            "card",
+            "field",
+            "set",
+            "card-1",
+            "--group",
+            "Documentation",
+            "--field",
+            "Specification",
+            "--value",
+            "specs/x.html",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("specs/x.html"));
+}
+
+/// The field name must also resolve through the base group, since the adopted
+/// group carries no fields of its own.
+#[tokio::test]
+async fn clear_resolves_names_through_the_base_group() {
+    let server = MockServer::start().await;
+    mount_resolution_fixtures(&server, &serde_json::json!([])).await;
+
+    Mock::given(method("DELETE"))
+        .and(path(
+            "/api/cards/card-1/custom-field-values/customFieldGroupId:card-group-1:customFieldId:field-1",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(value_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    plnk_with_server(&server.uri())
+        .args([
+            "card",
+            "field",
+            "clear",
+            "card-1",
+            "--group",
+            "Documentation",
+            "--field",
+            "Specification",
+        ])
+        .assert()
+        .success();
+}
+
+/// Clearing an already-unset value satisfies the intent, so it exits 0.
+#[tokio::test]
+async fn clear_on_an_unset_value_succeeds() {
+    let server = MockServer::start().await;
+    mount_resolution_fixtures(&server, &serde_json::json!([])).await;
+
+    Mock::given(method("DELETE"))
+        .and(path(
+            "/api/cards/card-1/custom-field-values/customFieldGroupId:card-group-1:customFieldId:field-1",
+        ))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "code": "E_NOT_FOUND",
+            "message": "Custom field value not found"
+        })))
+        .mount(&server)
+        .await;
+
+    plnk_with_server(&server.uri())
+        .args([
+            "card",
+            "field",
+            "clear",
+            "card-1",
+            "--group",
+            "Documentation",
+            "--field",
+            "Specification",
+        ])
+        .assert()
+        .success();
+}
+
+/// Passing IDs bypasses resolution entirely — no name lookups are needed, so
+/// this works against a card whose groups have no names at all.
+#[tokio::test]
+async fn set_by_id_bypasses_resolution() {
+    let server = MockServer::start().await;
+    mount_resolution_fixtures(&server, &serde_json::json!([])).await;
+
+    Mock::given(method("PATCH"))
+        .and(path(
+            "/api/cards/card-1/custom-field-values/customFieldGroupId:card-group-1:customFieldId:field-1",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(value_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    plnk_with_server(&server.uri())
+        .args([
+            "card",
+            "field",
+            "set",
+            "card-1",
+            "--group",
+            "card-group-1",
+            "--field",
+            "field-1",
+            "--value",
+            "specs/x.html",
+        ])
+        .assert()
+        .success();
+}
+
+/// An over-long value must fail before any request is issued. No HTTP mocks are
+/// mounted at all, so any request would fail the test.
+#[tokio::test]
+async fn over_long_value_exits_2_without_issuing_a_request() {
+    let server = MockServer::start().await;
+
+    plnk_with_server(&server.uri())
+        .args([
+            "card",
+            "field",
+            "set",
+            "card-1",
+            "--group",
+            "Documentation",
+            "--field",
+            "Specification",
+            "--value",
+            &"a".repeat(513),
+        ])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("512"));
+
+    assert!(
+        server.received_requests().await.unwrap().is_empty(),
+        "an over-long value must not reach the server"
+    );
+}
+
+/// A 512-character value is accepted — the boundary is inclusive.
+#[tokio::test]
+async fn value_at_the_limit_is_accepted() {
+    let server = MockServer::start().await;
+    mount_resolution_fixtures(&server, &serde_json::json!([])).await;
+
+    Mock::given(method("PATCH"))
+        .and(path(
+            "/api/cards/card-1/custom-field-values/customFieldGroupId:card-group-1:customFieldId:field-1",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(value_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    plnk_with_server(&server.uri())
+        .args([
+            "card",
+            "field",
+            "set",
+            "card-1",
+            "--group",
+            "Documentation",
+            "--field",
+            "Specification",
+            "--value",
+            &"a".repeat(512),
+        ])
+        .assert()
+        .success();
+}
+
+/// The server rejects an empty string outright, so there is no "set to empty"
+/// behaviour to expose — the message must point at `card field clear`.
+#[tokio::test]
+async fn empty_value_exits_2_and_names_clear() {
+    let server = MockServer::start().await;
+
+    plnk_with_server(&server.uri())
+        .args([
+            "card",
+            "field",
+            "set",
+            "card-1",
+            "--group",
+            "Documentation",
+            "--field",
+            "Specification",
+            "--value",
+            "",
+        ])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("card field clear"));
+
+    assert!(
+        server.received_requests().await.unwrap().is_empty(),
+        "an empty value must not reach the server"
+    );
+}
+
+#[tokio::test]
+async fn unknown_group_name_exits_4() {
+    let server = MockServer::start().await;
+    mount_resolution_fixtures(&server, &serde_json::json!([])).await;
+
+    plnk_with_server(&server.uri())
+        .args([
+            "card",
+            "field",
+            "set",
+            "card-1",
+            "--group",
+            "NoSuchGroup",
+            "--field",
+            "Specification",
+            "--value",
+            "x",
+        ])
+        .assert()
+        .code(4);
+}
+
+#[tokio::test]
+async fn unknown_field_name_exits_4() {
+    let server = MockServer::start().await;
+    mount_resolution_fixtures(&server, &serde_json::json!([])).await;
+
+    plnk_with_server(&server.uri())
+        .args([
+            "card",
+            "field",
+            "set",
+            "card-1",
+            "--group",
+            "Documentation",
+            "--field",
+            "NoSuchField",
+            "--value",
+            "x",
+        ])
+        .assert()
+        .code(4);
+}
+
+/// An ambiguous name must exit 2 and name every candidate, so the caller can
+/// pick an ID.
+#[tokio::test]
+async fn ambiguous_field_name_exits_2_and_lists_candidates() {
+    let server = MockServer::start().await;
+    mount_resolution_fixtures(
+        &server,
+        &serde_json::json!([{
+            "id": "field-2",
+            "name": "Speculative",
+            "position": 131_072.0,
+            "showOnFrontOfCard": false,
+            "customFieldGroupId": null,
+            "baseCustomFieldGroupId": "base-1",
+            "createdAt": "2026-08-10T00:00:00Z",
+            "updatedAt": null
+        }]),
+    )
+    .await;
+
+    plnk_with_server(&server.uri())
+        .args([
+            "card",
+            "field",
+            "set",
+            "card-1",
+            "--group",
+            "Documentation",
+            "--field",
+            "Spec",
+            "--value",
+            "x",
+        ])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("Specification"))
+        .stderr(predicate::str::contains("Speculative"))
+        .stderr(predicate::str::contains("field-1"))
+        .stderr(predicate::str::contains("field-2"));
+}
+
+/// An exact match must win over a substring match rather than being reported
+/// as ambiguous.
+#[tokio::test]
+async fn exact_name_match_beats_substring_match() {
+    let server = MockServer::start().await;
+    mount_resolution_fixtures(
+        &server,
+        &serde_json::json!([{
+            "id": "field-2",
+            "name": "Specification Notes",
+            "position": 131_072.0,
+            "showOnFrontOfCard": false,
+            "customFieldGroupId": null,
+            "baseCustomFieldGroupId": "base-1",
+            "createdAt": "2026-08-10T00:00:00Z",
+            "updatedAt": null
+        }]),
+    )
+    .await;
+
+    Mock::given(method("PATCH"))
+        .and(path(
+            "/api/cards/card-1/custom-field-values/customFieldGroupId:card-group-1:customFieldId:field-1",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(value_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    plnk_with_server(&server.uri())
+        .args([
+            "card",
+            "field",
+            "set",
+            "card-1",
+            "--group",
+            "Documentation",
+            "--field",
+            "Specification",
+            "--value",
+            "specs/x.html",
+        ])
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn list_values_renders_in_every_format() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/cards/card-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "item": {
+                "id": "card-1",
+                "listId": "list-1",
+                "boardId": "board-1",
+                "name": "A card",
+                "description": null,
+                "position": 65536.0,
+                "isSubscribed": false,
+                "createdAt": "2026-08-10T00:00:00Z",
+                "updatedAt": null
+            },
+            "included": {
+                "taskLists": [], "tasks": [], "cardLabels": [],
+                "cardMemberships": [], "attachments": [],
+                "customFieldGroups": [], "customFields": [],
+                "customFieldValues": [{
+                    "id": "value-1",
+                    "cardId": "card-1",
+                    "customFieldGroupId": "card-group-1",
+                    "customFieldId": "field-1",
+                    "content": "specs/x.html",
+                    "createdAt": "2026-08-10T00:00:00Z",
+                    "updatedAt": null
+                }]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    for format in ["table", "json", "markdown"] {
+        plnk_with_server(&server.uri())
+            .args(["card", "field", "list", "card-1", "--output", format])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("specs/x.html"));
+    }
+}

--- a/crates/plnk-core/src/api/mod.rs
+++ b/crates/plnk-core/src/api/mod.rs
@@ -5,7 +5,8 @@ pub mod v1;
 
 pub use search::{Named, match_by_name};
 pub use traits::{
-    AssigneeApi, AttachmentApi, BoardApi, CardApi, CardLabelApi, CommentApi, LabelApi, ListApi,
-    MembershipApi, ProjectApi, TaskApi, UserApi,
+    AssigneeApi, AttachmentApi, BoardApi, CardApi, CardCustomFieldApi, CardLabelApi, CommentApi,
+    CustomFieldApi, CustomFieldGroupApi, LabelApi, ListApi, MembershipApi, ProjectApi, TaskApi,
+    UserApi,
 };
 pub use v1::PlankaClientV1;

--- a/crates/plnk-core/src/api/responses.rs
+++ b/crates/plnk-core/src/api/responses.rs
@@ -55,6 +55,15 @@ pub(crate) struct BoardSnapshotIncluded {
     pub card_labels: Vec<crate::models::CardLabel>,
     #[serde(default)]
     pub board_memberships: Vec<crate::models::BoardMembership>,
+    #[serde(default)]
+    #[allow(dead_code)] // board-scoped groups are read via the board snapshot
+    pub custom_field_groups: Vec<crate::models::CustomFieldGroup>,
+    #[serde(default)]
+    #[allow(dead_code)] // board snapshot carries these; read via the group endpoint
+    pub custom_fields: Vec<crate::models::CustomField>,
+    #[serde(default)]
+    #[allow(dead_code)] // board-wide values are not surfaced; card scope is
+    pub custom_field_values: Vec<crate::models::CustomFieldValue>,
 }
 
 /// Project snapshot response — GET /api/projects/{id} returns nested included data.
@@ -72,6 +81,12 @@ pub(crate) struct ProjectSnapshotIncluded {
     pub boards: Vec<crate::models::Board>,
     #[serde(default)]
     pub project_managers: Vec<crate::models::ProjectManager>,
+    #[serde(default)]
+    #[allow(dead_code)] // consumed by CustomFieldGroupApi in the following task
+    pub base_custom_field_groups: Vec<crate::models::BaseCustomFieldGroup>,
+    #[serde(default)]
+    #[allow(dead_code)] // base-group fields are read from the projects list
+    pub custom_fields: Vec<crate::models::CustomField>,
 }
 
 /// Cards list response — GET /api/lists/{id}/cards returns items + included.
@@ -103,6 +118,57 @@ pub(crate) struct CardSnapshotIncluded {
     pub card_memberships: Vec<crate::models::CardMembership>,
     #[serde(default)]
     pub attachments: Vec<crate::models::Attachment>,
+    #[serde(default)]
+    #[allow(dead_code)] // consumed by CustomFieldGroupApi in the following task
+    pub custom_field_groups: Vec<crate::models::CustomFieldGroup>,
+    #[serde(default)]
+    #[allow(dead_code)] // consumed by CustomFieldApi in the following task
+    pub custom_fields: Vec<crate::models::CustomField>,
+    #[serde(default)]
+    #[allow(dead_code)] // consumed by CardCustomFieldApi in the following task
+    pub custom_field_values: Vec<crate::models::CustomFieldValue>,
+}
+
+/// Custom field group snapshot — GET /api/custom-field-groups/{id}.
+///
+/// Note: for a group adopted from a base group, `included.custom_fields` is
+/// empty — the fields belong to the base group, not to the adopted group.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // consumed by CustomFieldApi in the following task
+pub(crate) struct CustomFieldGroupSnapshot {
+    pub item: crate::models::CustomFieldGroup,
+    pub included: CustomFieldGroupSnapshotIncluded,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // consumed by CustomFieldApi in the following task
+pub(crate) struct CustomFieldGroupSnapshotIncluded {
+    #[serde(default)]
+    pub custom_fields: Vec<crate::models::CustomField>,
+}
+
+/// Projects list response — GET /api/projects.
+///
+/// This is the only endpoint that exposes base custom field groups together
+/// with their fields. There is no `GET /api/base-custom-field-groups/{id}`
+/// route: that path falls through to the SPA and returns HTML with `200`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // consumed by CustomFieldApi in the following task
+pub(crate) struct ProjectsListSnapshot {
+    pub included: ProjectsListSnapshotIncluded,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // consumed by CustomFieldApi in the following task
+pub(crate) struct ProjectsListSnapshotIncluded {
+    #[serde(default)]
+    pub base_custom_field_groups: Vec<crate::models::BaseCustomFieldGroup>,
+    #[serde(default)]
+    pub custom_fields: Vec<crate::models::CustomField>,
 }
 
 /// Comments list response — GET /api/cards/{id}/comments.

--- a/crates/plnk-core/src/api/responses.rs
+++ b/crates/plnk-core/src/api/responses.rs
@@ -56,10 +56,9 @@ pub(crate) struct BoardSnapshotIncluded {
     #[serde(default)]
     pub board_memberships: Vec<crate::models::BoardMembership>,
     #[serde(default)]
-    #[allow(dead_code)] // board-scoped groups are read via the board snapshot
     pub custom_field_groups: Vec<crate::models::CustomFieldGroup>,
     #[serde(default)]
-    #[allow(dead_code)] // board snapshot carries these; read via the group endpoint
+    #[allow(dead_code)] // board-wide fields are read per-group instead
     pub custom_fields: Vec<crate::models::CustomField>,
     #[serde(default)]
     #[allow(dead_code)] // board-wide values are not surfaced; card scope is
@@ -82,7 +81,6 @@ pub(crate) struct ProjectSnapshotIncluded {
     #[serde(default)]
     pub project_managers: Vec<crate::models::ProjectManager>,
     #[serde(default)]
-    #[allow(dead_code)] // consumed by CustomFieldGroupApi in the following task
     pub base_custom_field_groups: Vec<crate::models::BaseCustomFieldGroup>,
     #[serde(default)]
     #[allow(dead_code)] // base-group fields are read from the projects list
@@ -119,13 +117,10 @@ pub(crate) struct CardSnapshotIncluded {
     #[serde(default)]
     pub attachments: Vec<crate::models::Attachment>,
     #[serde(default)]
-    #[allow(dead_code)] // consumed by CustomFieldGroupApi in the following task
     pub custom_field_groups: Vec<crate::models::CustomFieldGroup>,
     #[serde(default)]
-    #[allow(dead_code)] // consumed by CustomFieldApi in the following task
     pub custom_fields: Vec<crate::models::CustomField>,
     #[serde(default)]
-    #[allow(dead_code)] // consumed by CardCustomFieldApi in the following task
     pub custom_field_values: Vec<crate::models::CustomFieldValue>,
 }
 
@@ -135,7 +130,6 @@ pub(crate) struct CardSnapshotIncluded {
 /// empty — the fields belong to the base group, not to the adopted group.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)] // consumed by CustomFieldApi in the following task
 pub(crate) struct CustomFieldGroupSnapshot {
     pub item: crate::models::CustomFieldGroup,
     pub included: CustomFieldGroupSnapshotIncluded,
@@ -143,7 +137,6 @@ pub(crate) struct CustomFieldGroupSnapshot {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)] // consumed by CustomFieldApi in the following task
 pub(crate) struct CustomFieldGroupSnapshotIncluded {
     #[serde(default)]
     pub custom_fields: Vec<crate::models::CustomField>,
@@ -156,14 +149,12 @@ pub(crate) struct CustomFieldGroupSnapshotIncluded {
 /// route: that path falls through to the SPA and returns HTML with `200`.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)] // consumed by CustomFieldApi in the following task
 pub(crate) struct ProjectsListSnapshot {
     pub included: ProjectsListSnapshotIncluded,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)] // consumed by CustomFieldApi in the following task
 pub(crate) struct ProjectsListSnapshotIncluded {
     #[serde(default)]
     pub base_custom_field_groups: Vec<crate::models::BaseCustomFieldGroup>,

--- a/crates/plnk-core/src/api/search.rs
+++ b/crates/plnk-core/src/api/search.rs
@@ -70,6 +70,28 @@ impl Named for crate::models::Label {
     }
 }
 
+impl Named for crate::models::CustomField {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Named for crate::models::BaseCustomFieldGroup {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// A custom field group's own `name` is `None` when it was adopted from a base
+/// group — the display name then lives on the base group. Matching on this impl
+/// alone will therefore miss every template-adopted group; callers that need to
+/// match adopted groups must resolve the base group's name first.
+impl Named for crate::models::CustomFieldGroup {
+    fn name(&self) -> &str {
+        self.name.as_deref().unwrap_or("")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/plnk-core/src/api/traits.rs
+++ b/crates/plnk-core/src/api/traits.rs
@@ -10,10 +10,11 @@ use async_trait::async_trait;
 
 use crate::error::PlankaError;
 use crate::models::{
-    Attachment, Board, BoardMembership, Card, CardBatchGetResult, CardLabel, CardMembership,
-    Comment, CreateBoard, CreateCard, CreateComment, CreateList, CreateProject, FindScope, Label,
-    List, MoveCard, Project, ProjectManager, Task, UpdateBoard, UpdateCard, UpdateComment,
-    UpdateLabel, UpdateList, UpdateProject, UpdateTask, User,
+    Attachment, BaseCustomFieldGroup, Board, BoardMembership, Card, CardBatchGetResult, CardLabel,
+    CardMembership, Comment, CreateBoard, CreateCard, CreateComment, CreateList, CreateProject,
+    CustomField, CustomFieldGroup, CustomFieldValue, FindScope, Label, List, MoveCard, Project,
+    ProjectManager, Task, UpdateBoard, UpdateCard, UpdateComment, UpdateCustomField,
+    UpdateCustomFieldGroup, UpdateLabel, UpdateList, UpdateProject, UpdateTask, User,
 };
 
 #[async_trait]
@@ -139,6 +140,127 @@ pub trait CardLabelApi {
     async fn add_card_label(&self, card_id: &str, label_id: &str)
     -> Result<CardLabel, PlankaError>;
     async fn remove_card_label(&self, card_id: &str, label_id: &str) -> Result<(), PlankaError>;
+}
+
+/// Custom field groups: the reusable project-level templates (base groups) and
+/// the board- and card-level groups that hold fields.
+///
+/// Base groups are a separate resource from ordinary groups on the wire, with
+/// their own routes, and are therefore given their own methods here rather than
+/// being folded into the group methods. In particular there is **no
+/// `GET /api/base-custom-field-groups/{id}`** route — that path falls through to
+/// the Planka SPA and returns HTML with `200` — so `get_base_field_group` reads
+/// the projects list instead.
+#[async_trait]
+pub trait CustomFieldGroupApi {
+    /// Base groups defined on a project, read from the project snapshot.
+    async fn list_base_field_groups(
+        &self,
+        project_id: &str,
+    ) -> Result<Vec<BaseCustomFieldGroup>, PlankaError>;
+    /// Look up a single base group by id.
+    ///
+    /// Reads `GET /api/projects` because no by-id route exists for base groups.
+    async fn get_base_field_group(&self, id: &str) -> Result<BaseCustomFieldGroup, PlankaError>;
+    async fn list_field_groups_for_board(
+        &self,
+        board_id: &str,
+    ) -> Result<Vec<CustomFieldGroup>, PlankaError>;
+    async fn list_field_groups_for_card(
+        &self,
+        card_id: &str,
+    ) -> Result<Vec<CustomFieldGroup>, PlankaError>;
+    async fn get_field_group(&self, id: &str) -> Result<CustomFieldGroup, PlankaError>;
+    async fn create_base_field_group(
+        &self,
+        project_id: &str,
+        name: &str,
+    ) -> Result<BaseCustomFieldGroup, PlankaError>;
+    async fn create_board_field_group(
+        &self,
+        board_id: &str,
+        name: &str,
+    ) -> Result<CustomFieldGroup, PlankaError>;
+    /// Attach a group to a card, either by adopting a base group (`base_id`) or
+    /// as a one-off named group. Exactly one of the two must be supplied.
+    async fn create_card_field_group(
+        &self,
+        card_id: &str,
+        base_id: Option<&str>,
+        name: Option<&str>,
+    ) -> Result<CustomFieldGroup, PlankaError>;
+    async fn update_field_group(
+        &self,
+        id: &str,
+        params: UpdateCustomFieldGroup,
+    ) -> Result<CustomFieldGroup, PlankaError>;
+    async fn update_base_field_group(
+        &self,
+        id: &str,
+        params: UpdateCustomFieldGroup,
+    ) -> Result<BaseCustomFieldGroup, PlankaError>;
+    async fn delete_field_group(&self, id: &str) -> Result<(), PlankaError>;
+    async fn delete_base_field_group(&self, id: &str) -> Result<(), PlankaError>;
+}
+
+/// Custom fields: the named slots inside a group.
+///
+/// Every method takes a `base` flag alongside the group id because base groups
+/// and ordinary groups are distinct wire resources reached by different routes.
+/// Reading a base group's fields is only possible through the projects list.
+#[async_trait]
+pub trait CustomFieldApi {
+    async fn list_fields(
+        &self,
+        group_id: &str,
+        base: bool,
+    ) -> Result<Vec<CustomField>, PlankaError>;
+    /// Every custom field defined by the card's own groups, read from the card
+    /// snapshot in a single call.
+    ///
+    /// Fields belonging to an adopted group's *base* group are not included —
+    /// those live on the base group and must be fetched with
+    /// `list_fields(base_id, true)`.
+    async fn list_fields_for_card(&self, card_id: &str) -> Result<Vec<CustomField>, PlankaError>;
+    async fn find_fields(
+        &self,
+        group_id: &str,
+        base: bool,
+        name: &str,
+    ) -> Result<Vec<CustomField>, PlankaError>;
+    async fn create_field(
+        &self,
+        group_id: &str,
+        base: bool,
+        name: &str,
+        show_on_front: bool,
+    ) -> Result<CustomField, PlankaError>;
+    async fn update_field(
+        &self,
+        id: &str,
+        params: UpdateCustomField,
+    ) -> Result<CustomField, PlankaError>;
+    async fn delete_field(&self, id: &str) -> Result<(), PlankaError>;
+}
+
+/// Custom field values stored against a card.
+#[async_trait]
+pub trait CardCustomFieldApi {
+    async fn list_field_values(&self, card_id: &str) -> Result<Vec<CustomFieldValue>, PlankaError>;
+    async fn set_field_value(
+        &self,
+        card_id: &str,
+        group_id: &str,
+        field_id: &str,
+        content: &str,
+    ) -> Result<CustomFieldValue, PlankaError>;
+    /// Remove a value. Idempotent: an already-unset value is a success.
+    async fn clear_field_value(
+        &self,
+        card_id: &str,
+        group_id: &str,
+        field_id: &str,
+    ) -> Result<(), PlankaError>;
 }
 
 #[async_trait]

--- a/crates/plnk-core/src/api/traits.rs
+++ b/crates/plnk-core/src/api/traits.rs
@@ -158,6 +158,12 @@ pub trait CustomFieldGroupApi {
         &self,
         project_id: &str,
     ) -> Result<Vec<BaseCustomFieldGroup>, PlankaError>;
+    /// Every base group the caller can see, in one request.
+    ///
+    /// Deliberately unscoped: `GET /api/projects` is the only endpoint that
+    /// exposes base groups at all, and resolving a card's adopted groups needs
+    /// their names without first walking card to board to project.
+    async fn list_all_base_field_groups(&self) -> Result<Vec<BaseCustomFieldGroup>, PlankaError>;
     /// Look up a single base group by id.
     ///
     /// Reads `GET /api/projects` because no by-id route exists for base groups.

--- a/crates/plnk-core/src/api/v1.rs
+++ b/crates/plnk-core/src/api/v1.rs
@@ -13,21 +13,23 @@ use tracing::debug;
 use crate::client::HttpClient;
 use crate::error::PlankaError;
 use crate::models::{
-    Attachment, Board, BoardMembership, Card, CardBatchFailure, CardBatchGetResult, CardLabel,
-    CardMembership, Comment, CreateBoard, CreateCard, CreateCardMembership, CreateComment,
-    CreateList, CreateProject, CreateTaskList, FindScope, Label, List, MoveCard, Project,
-    ProjectManager, Task, UpdateBoard, UpdateCard, UpdateComment, UpdateLabel, UpdateList,
-    UpdateProject, UpdateTask, User,
+    Attachment, BaseCustomFieldGroup, Board, BoardMembership, Card, CardBatchFailure,
+    CardBatchGetResult, CardLabel, CardMembership, Comment, CreateBoard, CreateCard,
+    CreateCardMembership, CreateComment, CreateList, CreateProject, CreateTaskList, CustomField,
+    CustomFieldGroup, CustomFieldValue, FindScope, Label, List, MoveCard, Project, ProjectManager,
+    Task, UpdateBoard, UpdateCard, UpdateComment, UpdateCustomField, UpdateCustomFieldGroup,
+    UpdateLabel, UpdateList, UpdateProject, UpdateTask, User,
 };
 
 use super::responses::{
-    BoardSnapshot, CardSnapshot, CardsListResponse, CommentsListResponse, ItemResponse,
-    ItemsResponse, ProjectSnapshot,
+    BoardSnapshot, CardSnapshot, CardsListResponse, CommentsListResponse, CustomFieldGroupSnapshot,
+    ItemResponse, ItemsResponse, ProjectSnapshot, ProjectsListSnapshot,
 };
 use super::search::match_by_name;
 use super::traits::{
-    AssigneeApi, AttachmentApi, BoardApi, CardApi, CardLabelApi, CommentApi, LabelApi, ListApi,
-    MembershipApi, ProjectApi, TaskApi, UserApi,
+    AssigneeApi, AttachmentApi, BoardApi, CardApi, CardCustomFieldApi, CardLabelApi, CommentApi,
+    CustomFieldApi, CustomFieldGroupApi, LabelApi, ListApi, MembershipApi, ProjectApi, TaskApi,
+    UserApi,
 };
 
 /// Concrete Planka API client for the current server version.
@@ -916,6 +918,374 @@ impl MembershipApi for PlankaClientV1 {
         self.http
             .delete(&format!("/api/project-managers/{id}"))
             .await
+    }
+}
+
+// ── Custom fields ───────────────────────────────────────────────────────
+
+/// Build the composite path segment that addresses a single custom field value.
+///
+/// Planka does not use ordinary path parameters here — group and field ids are
+/// packed into one segment. Planka's published `OpenAPI` spec writes this as
+/// `customFieldId:${customFieldId}` with a literal `$`; that is a documentation
+/// bug. Sending the `$` returns `400 E_MISSING_OR_INVALID_PARAMS` because the
+/// server reads it as part of the id and fails a length check.
+fn custom_field_value_path(card_id: &str, group_id: &str, field_id: &str) -> String {
+    format!(
+        "/api/cards/{card_id}/custom-field-values/customFieldGroupId:{group_id}:customFieldId:{field_id}"
+    )
+}
+
+#[async_trait]
+impl CustomFieldGroupApi for PlankaClientV1 {
+    async fn list_base_field_groups(
+        &self,
+        project_id: &str,
+    ) -> Result<Vec<BaseCustomFieldGroup>, PlankaError> {
+        let resp: ProjectSnapshot = self
+            .http
+            .get(&format!("/api/projects/{project_id}"))
+            .await?;
+        Ok(resp.included.base_custom_field_groups)
+    }
+
+    async fn get_base_field_group(&self, id: &str) -> Result<BaseCustomFieldGroup, PlankaError> {
+        // There is no `GET /api/base-custom-field-groups/{id}` route: that path
+        // falls through to the SPA and returns HTML with 200, so it cannot be
+        // used. The projects list is the only endpoint exposing base groups.
+        let resp: ProjectsListSnapshot = self.http.get("/api/projects").await?;
+        resp.included
+            .base_custom_field_groups
+            .into_iter()
+            .find(|group| group.id == id)
+            .ok_or_else(|| PlankaError::NotFound {
+                resource_type: "base custom field group".to_string(),
+                id: id.to_string(),
+            })
+    }
+
+    async fn list_field_groups_for_board(
+        &self,
+        board_id: &str,
+    ) -> Result<Vec<CustomFieldGroup>, PlankaError> {
+        let resp: BoardSnapshot = self.http.get(&format!("/api/boards/{board_id}")).await?;
+        Ok(resp.included.custom_field_groups)
+    }
+
+    async fn list_field_groups_for_card(
+        &self,
+        card_id: &str,
+    ) -> Result<Vec<CustomFieldGroup>, PlankaError> {
+        let resp: CardSnapshot = self.http.get(&format!("/api/cards/{card_id}")).await?;
+        Ok(resp.included.custom_field_groups)
+    }
+
+    async fn get_field_group(&self, id: &str) -> Result<CustomFieldGroup, PlankaError> {
+        let resp: CustomFieldGroupSnapshot = self
+            .http
+            .get(&format!("/api/custom-field-groups/{id}"))
+            .await?;
+        Ok(resp.item)
+    }
+
+    async fn create_base_field_group(
+        &self,
+        project_id: &str,
+        name: &str,
+    ) -> Result<BaseCustomFieldGroup, PlankaError> {
+        #[derive(serde::Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Payload {
+            name: String,
+            position: f64,
+        }
+
+        let payload = Payload {
+            name: name.to_string(),
+            position: 65536.0,
+        };
+        let resp: ItemResponse<BaseCustomFieldGroup> = self
+            .http
+            .post(
+                &format!("/api/projects/{project_id}/base-custom-field-groups"),
+                &payload,
+            )
+            .await?;
+        Ok(resp.item)
+    }
+
+    async fn create_board_field_group(
+        &self,
+        board_id: &str,
+        name: &str,
+    ) -> Result<CustomFieldGroup, PlankaError> {
+        #[derive(serde::Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Payload {
+            name: String,
+            position: f64,
+        }
+
+        let payload = Payload {
+            name: name.to_string(),
+            position: 65536.0,
+        };
+        let resp: ItemResponse<CustomFieldGroup> = self
+            .http
+            .post(
+                &format!("/api/boards/{board_id}/custom-field-groups"),
+                &payload,
+            )
+            .await?;
+        Ok(resp.item)
+    }
+
+    async fn create_card_field_group(
+        &self,
+        card_id: &str,
+        base_id: Option<&str>,
+        name: Option<&str>,
+    ) -> Result<CustomFieldGroup, PlankaError> {
+        // `baseCustomFieldGroupId` and `name` are mutually exclusive on the
+        // wire: adopting a template carries no name of its own.
+        #[derive(serde::Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Payload {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            base_custom_field_group_id: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            name: Option<String>,
+            position: f64,
+        }
+
+        let payload = match (base_id, name) {
+            (Some(base), _) => Payload {
+                base_custom_field_group_id: Some(base.to_string()),
+                name: None,
+                position: 65536.0,
+            },
+            (None, Some(group_name)) => Payload {
+                base_custom_field_group_id: None,
+                name: Some(group_name.to_string()),
+                position: 65536.0,
+            },
+            (None, None) => {
+                return Err(PlankaError::MissingRequiredOption {
+                    field: "--base or --name".to_string(),
+                });
+            }
+        };
+
+        // The server may reposition the group when a sibling already occupies
+        // the requested slot — the echoed position is not asserted.
+        let resp: ItemResponse<CustomFieldGroup> = self
+            .http
+            .post(
+                &format!("/api/cards/{card_id}/custom-field-groups"),
+                &payload,
+            )
+            .await?;
+        Ok(resp.item)
+    }
+
+    async fn update_field_group(
+        &self,
+        id: &str,
+        params: UpdateCustomFieldGroup,
+    ) -> Result<CustomFieldGroup, PlankaError> {
+        let resp: ItemResponse<CustomFieldGroup> = self
+            .http
+            .patch(&format!("/api/custom-field-groups/{id}"), &params)
+            .await?;
+        Ok(resp.item)
+    }
+
+    async fn update_base_field_group(
+        &self,
+        id: &str,
+        params: UpdateCustomFieldGroup,
+    ) -> Result<BaseCustomFieldGroup, PlankaError> {
+        // PATCH exists on this route even though GET does not.
+        let resp: ItemResponse<BaseCustomFieldGroup> = self
+            .http
+            .patch(&format!("/api/base-custom-field-groups/{id}"), &params)
+            .await?;
+        Ok(resp.item)
+    }
+
+    async fn delete_field_group(&self, id: &str) -> Result<(), PlankaError> {
+        self.http
+            .delete(&format!("/api/custom-field-groups/{id}"))
+            .await
+    }
+
+    async fn delete_base_field_group(&self, id: &str) -> Result<(), PlankaError> {
+        self.http
+            .delete(&format!("/api/base-custom-field-groups/{id}"))
+            .await
+    }
+}
+
+#[async_trait]
+impl CustomFieldApi for PlankaClientV1 {
+    async fn list_fields(
+        &self,
+        group_id: &str,
+        base: bool,
+    ) -> Result<Vec<CustomField>, PlankaError> {
+        if base {
+            // Base group fields appear only in the projects list — neither the
+            // board snapshot nor any by-id base-group route exposes them.
+            let resp: ProjectsListSnapshot = self.http.get("/api/projects").await?;
+            if !resp
+                .included
+                .base_custom_field_groups
+                .iter()
+                .any(|group| group.id == group_id)
+            {
+                return Err(PlankaError::NotFound {
+                    resource_type: "base custom field group".to_string(),
+                    id: group_id.to_string(),
+                });
+            }
+            return Ok(resp
+                .included
+                .custom_fields
+                .into_iter()
+                .filter(|field| field.base_custom_field_group_id.as_deref() == Some(group_id))
+                .collect());
+        }
+
+        let resp: CustomFieldGroupSnapshot = self
+            .http
+            .get(&format!("/api/custom-field-groups/{group_id}"))
+            .await?;
+        Ok(resp.included.custom_fields)
+    }
+
+    async fn list_fields_for_card(&self, card_id: &str) -> Result<Vec<CustomField>, PlankaError> {
+        let resp: CardSnapshot = self.http.get(&format!("/api/cards/{card_id}")).await?;
+        Ok(resp.included.custom_fields)
+    }
+
+    async fn find_fields(
+        &self,
+        group_id: &str,
+        base: bool,
+        name: &str,
+    ) -> Result<Vec<CustomField>, PlankaError> {
+        let fields = self.list_fields(group_id, base).await?;
+        let matched = match_by_name(&fields, name);
+        Ok(matched.into_iter().cloned().collect())
+    }
+
+    async fn create_field(
+        &self,
+        group_id: &str,
+        base: bool,
+        name: &str,
+        show_on_front: bool,
+    ) -> Result<CustomField, PlankaError> {
+        #[derive(serde::Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Payload {
+            name: String,
+            position: f64,
+            show_on_front_of_card: bool,
+        }
+
+        let payload = Payload {
+            name: name.to_string(),
+            position: 65536.0,
+            show_on_front_of_card: show_on_front,
+        };
+        let path = if base {
+            format!("/api/base-custom-field-groups/{group_id}/custom-fields")
+        } else {
+            format!("/api/custom-field-groups/{group_id}/custom-fields")
+        };
+        let resp: ItemResponse<CustomField> = self.http.post(&path, &payload).await?;
+        Ok(resp.item)
+    }
+
+    async fn update_field(
+        &self,
+        id: &str,
+        params: UpdateCustomField,
+    ) -> Result<CustomField, PlankaError> {
+        let resp: ItemResponse<CustomField> = self
+            .http
+            .patch(&format!("/api/custom-fields/{id}"), &params)
+            .await?;
+        Ok(resp.item)
+    }
+
+    async fn delete_field(&self, id: &str) -> Result<(), PlankaError> {
+        self.http.delete(&format!("/api/custom-fields/{id}")).await
+    }
+}
+
+#[async_trait]
+impl CardCustomFieldApi for PlankaClientV1 {
+    async fn list_field_values(&self, card_id: &str) -> Result<Vec<CustomFieldValue>, PlankaError> {
+        let resp: CardSnapshot = self.http.get(&format!("/api/cards/{card_id}")).await?;
+        Ok(resp.included.custom_field_values)
+    }
+
+    async fn set_field_value(
+        &self,
+        card_id: &str,
+        group_id: &str,
+        field_id: &str,
+        content: &str,
+    ) -> Result<CustomFieldValue, PlankaError> {
+        #[derive(serde::Serialize)]
+        struct Payload {
+            content: String,
+        }
+
+        let payload = Payload {
+            content: content.to_string(),
+        };
+        let resp: ItemResponse<CustomFieldValue> = self
+            .http
+            .patch(
+                &custom_field_value_path(card_id, group_id, field_id),
+                &payload,
+            )
+            .await?;
+        Ok(resp.item)
+    }
+
+    /// Remove a value, treating "already unset" as success.
+    ///
+    /// This is a deliberate departure from the crate's usual "errors are data"
+    /// stance. The intent of clearing is *ensure this field carries no value*,
+    /// which an already-unset field satisfies, so scripts should not have to
+    /// branch on it. Only a 404 from this specific route is swallowed; every
+    /// other status maps to its normal typed error.
+    ///
+    /// Note the route is **plural** (`custom-field-values`). Planka's published
+    /// spec spells the DELETE path singular; that route does not exist and
+    /// returns a bare `{"code":"E_NOT_FOUND"}` with no message.
+    async fn clear_field_value(
+        &self,
+        card_id: &str,
+        group_id: &str,
+        field_id: &str,
+    ) -> Result<(), PlankaError> {
+        match self
+            .http
+            .delete(&custom_field_value_path(card_id, group_id, field_id))
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(PlankaError::Remote404 { .. }) => {
+                debug!("custom field value already unset; treating clear as a no-op");
+                Ok(())
+            }
+            Err(other) => Err(other),
+        }
     }
 }
 

--- a/crates/plnk-core/src/api/v1.rs
+++ b/crates/plnk-core/src/api/v1.rs
@@ -949,6 +949,11 @@ impl CustomFieldGroupApi for PlankaClientV1 {
         Ok(resp.included.base_custom_field_groups)
     }
 
+    async fn list_all_base_field_groups(&self) -> Result<Vec<BaseCustomFieldGroup>, PlankaError> {
+        let resp: ProjectsListSnapshot = self.http.get("/api/projects").await?;
+        Ok(resp.included.base_custom_field_groups)
+    }
+
     async fn get_base_field_group(&self, id: &str) -> Result<BaseCustomFieldGroup, PlankaError> {
         // There is no `GET /api/base-custom-field-groups/{id}` route: that path
         // falls through to the SPA and returns HTML with 200, so it cannot be

--- a/crates/plnk-core/src/models/custom_field.rs
+++ b/crates/plnk-core/src/models/custom_field.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Serialize};
+
+use super::ResourceId;
+
+/// A reusable custom field group template attached to a project.
+///
+/// Base groups carry no `position` — the create request accepts one but the
+/// response omits it, so the field is deliberately absent from this model.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BaseCustomFieldGroup {
+    pub id: ResourceId,
+    pub project_id: ResourceId,
+    pub name: String,
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
+/// A custom field group attached to a board or a card.
+///
+/// `name` is `None` when the group was adopted from a base group — the display
+/// name then lives on the base group referenced by `base_custom_field_group_id`.
+/// `board_id` and `card_id` are mutually exclusive in practice, as are
+/// `name` and `base_custom_field_group_id`; neither exclusivity is encoded in
+/// the type, matching how the wire format represents them.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomFieldGroup {
+    pub id: ResourceId,
+    pub name: Option<String>,
+    #[serde(default)]
+    pub board_id: Option<ResourceId>,
+    #[serde(default)]
+    pub card_id: Option<ResourceId>,
+    #[serde(default)]
+    pub base_custom_field_group_id: Option<ResourceId>,
+    pub position: f64,
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
+/// A named slot inside a custom field group.
+///
+/// `custom_field_group_id` and `base_custom_field_group_id` are mutually
+/// exclusive: a field belongs either to a board/card group or to a base group.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomField {
+    pub id: ResourceId,
+    pub name: String,
+    pub position: f64,
+    pub show_on_front_of_card: bool,
+    #[serde(default)]
+    pub custom_field_group_id: Option<ResourceId>,
+    #[serde(default)]
+    pub base_custom_field_group_id: Option<ResourceId>,
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
+/// A value stored against a card for one (group, field) pair.
+///
+/// Planka stores every value as a string; `content` is capped at 512
+/// characters server-side and may not be empty.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomFieldValue {
+    pub id: ResourceId,
+    pub card_id: ResourceId,
+    pub custom_field_group_id: ResourceId,
+    pub custom_field_id: ResourceId,
+    pub content: String,
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
+/// Maximum length of a custom field value, enforced server-side.
+///
+/// Verified against a live server: 512 characters returns `200`, 513 returns
+/// `400`. Validated client-side so callers get a validation error instead of a
+/// wasted round trip.
+pub const CUSTOM_FIELD_VALUE_MAX_LEN: usize = 512;
+
+/// Parameters for updating a custom field group.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateCustomFieldGroup {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// Parameters for updating a custom field.
+///
+/// `show_on_front_of_card` is `Option<bool>` so that "leave unchanged" and
+/// "set to false" stay distinguishable in a PATCH body.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateCustomField {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub show_on_front_of_card: Option<bool>,
+}

--- a/crates/plnk-core/src/models/mod.rs
+++ b/crates/plnk-core/src/models/mod.rs
@@ -3,6 +3,7 @@ mod board;
 mod card;
 mod comment;
 mod common;
+mod custom_field;
 mod label;
 mod list;
 mod membership;
@@ -17,6 +18,7 @@ pub use board::*;
 pub use card::*;
 pub use comment::*;
 pub use common::*;
+pub use custom_field::*;
 pub use label::*;
 pub use list::*;
 pub use membership::*;
@@ -150,5 +152,44 @@ impl Tabular for CardMembership {
 impl Tabular for CardLabel {
     fn trimmed_columns() -> &'static [(&'static str, &'static str)] {
         &[("id", "ID"), ("cardId", "Card"), ("labelId", "Label")]
+    }
+}
+
+impl Tabular for BaseCustomFieldGroup {
+    fn trimmed_columns() -> &'static [(&'static str, &'static str)] {
+        &[("id", "ID"), ("name", "Name"), ("projectId", "Project")]
+    }
+}
+
+impl Tabular for CustomFieldGroup {
+    fn trimmed_columns() -> &'static [(&'static str, &'static str)] {
+        &[
+            ("id", "ID"),
+            ("name", "Name"),
+            ("cardId", "Card"),
+            ("boardId", "Board"),
+            ("position", "Position"),
+        ]
+    }
+}
+
+impl Tabular for CustomField {
+    fn trimmed_columns() -> &'static [(&'static str, &'static str)] {
+        &[
+            ("id", "ID"),
+            ("name", "Name"),
+            ("showOnFrontOfCard", "On Front"),
+            ("position", "Position"),
+        ]
+    }
+}
+
+impl Tabular for CustomFieldValue {
+    fn trimmed_columns() -> &'static [(&'static str, &'static str)] {
+        &[
+            ("id", "ID"),
+            ("customFieldId", "Field"),
+            ("content", "Content"),
+        ]
     }
 }

--- a/crates/plnk-core/src/models/mod.rs
+++ b/crates/plnk-core/src/models/mod.rs
@@ -163,9 +163,13 @@ impl Tabular for BaseCustomFieldGroup {
 
 impl Tabular for CustomFieldGroup {
     fn trimmed_columns() -> &'static [(&'static str, &'static str)] {
+        // `baseCustomFieldGroupId` earns its place in the trimmed view: an
+        // adopted group's own `name` is null, so without it the row is a blank
+        // name with nothing explaining why.
         &[
             ("id", "ID"),
             ("name", "Name"),
+            ("baseCustomFieldGroupId", "Base Group"),
             ("cardId", "Card"),
             ("boardId", "Board"),
             ("position", "Position"),

--- a/crates/plnk-core/src/models/tests.rs
+++ b/crates/plnk-core/src/models/tests.rs
@@ -555,6 +555,54 @@ fn tabular_fields_exist_in_serde_representation() {
         },
         "CardLabel",
     );
+    check(
+        &BaseCustomFieldGroup {
+            id: "1".into(),
+            project_id: "2".into(),
+            name: "Documentation".into(),
+            created_at: "t".into(),
+            updated_at: None,
+        },
+        "BaseCustomFieldGroup",
+    );
+    check(
+        &CustomFieldGroup {
+            id: "1".into(),
+            name: None,
+            board_id: None,
+            card_id: Some("2".into()),
+            base_custom_field_group_id: Some("3".into()),
+            position: 65536.0,
+            created_at: "t".into(),
+            updated_at: None,
+        },
+        "CustomFieldGroup",
+    );
+    check(
+        &CustomField {
+            id: "1".into(),
+            name: "Specification".into(),
+            position: 65536.0,
+            show_on_front_of_card: true,
+            custom_field_group_id: Some("2".into()),
+            base_custom_field_group_id: None,
+            created_at: "t".into(),
+            updated_at: None,
+        },
+        "CustomField",
+    );
+    check(
+        &CustomFieldValue {
+            id: "1".into(),
+            card_id: "2".into(),
+            custom_field_group_id: "3".into(),
+            custom_field_id: "4".into(),
+            content: "specs/x.html".into(),
+            created_at: "t".into(),
+            updated_at: None,
+        },
+        "CustomFieldValue",
+    );
 }
 
 #[test]
@@ -599,4 +647,224 @@ fn create_list_serializes_with_type() {
     let json = serde_json::to_value(&params).unwrap();
     assert_eq!(json["type"], "active");
     assert_eq!(json["boardId"], "456");
+}
+
+// --- custom fields -------------------------------------------------------
+//
+// Payloads below are captured verbatim from a live Planka server (2026-08-10).
+
+#[test]
+fn base_custom_field_group_deserialize_from_planka_api() {
+    let api_json = serde_json::json!({
+        "id": "1838314588785870118",
+        "createdAt": "2026-08-10T04:22:56.098Z",
+        "updatedAt": null,
+        "name": "Documentation",
+        "projectId": "1838286221441238832"
+    });
+
+    let group: BaseCustomFieldGroup = serde_json::from_value(api_json).unwrap();
+    assert_eq!(group.id, "1838314588785870118");
+    assert_eq!(group.name, "Documentation");
+    assert_eq!(group.project_id, "1838286221441238832");
+    assert!(group.updated_at.is_none());
+}
+
+/// A base group's create response omits `position` entirely even though the
+/// create request accepts one — the model must not require it.
+#[test]
+fn base_custom_field_group_deserializes_without_position() {
+    let api_json = serde_json::json!({
+        "id": "1",
+        "createdAt": "t",
+        "updatedAt": null,
+        "name": "Docs",
+        "projectId": "2"
+    });
+
+    let group: BaseCustomFieldGroup = serde_json::from_value(api_json).unwrap();
+    let round_tripped = serde_json::to_value(&group).unwrap();
+    assert!(
+        round_tripped.get("position").is_none(),
+        "base groups carry no position"
+    );
+}
+
+/// The load-bearing case: a card group adopted from a base group has a null
+/// `name`, with the display name living on the base group.
+#[test]
+fn custom_field_group_adopted_from_base_has_null_name() {
+    let api_json = serde_json::json!({
+        "id": "1838315093998175530",
+        "createdAt": "2026-08-10T04:23:56.324Z",
+        "updatedAt": null,
+        "position": 81920.0,
+        "name": null,
+        "boardId": null,
+        "cardId": "1838300473224856753",
+        "baseCustomFieldGroupId": "1838314588785870118"
+    });
+
+    let group: CustomFieldGroup = serde_json::from_value(api_json).unwrap();
+    assert!(group.name.is_none(), "adopted groups carry a null name");
+    assert_eq!(
+        group.base_custom_field_group_id,
+        Some("1838314588785870118".to_string())
+    );
+    assert_eq!(group.card_id, Some("1838300473224856753".to_string()));
+    assert!(group.board_id.is_none());
+}
+
+#[test]
+fn custom_field_group_local_to_card_has_name_and_no_base() {
+    let api_json = serde_json::json!({
+        "id": "1838305759222301878",
+        "createdAt": "2026-08-10T04:05:23.532Z",
+        "updatedAt": "2026-08-10T04:09:26.759Z",
+        "position": 65536.0,
+        "name": "Documentation",
+        "boardId": null,
+        "cardId": "1838300473224856753",
+        "baseCustomFieldGroupId": null
+    });
+
+    let group: CustomFieldGroup = serde_json::from_value(api_json).unwrap();
+    assert_eq!(group.name, Some("Documentation".to_string()));
+    assert!(group.base_custom_field_group_id.is_none());
+}
+
+#[test]
+fn custom_field_belonging_to_base_group_deserializes() {
+    let api_json = serde_json::json!({
+        "id": "1838314715311244583",
+        "createdAt": "2026-08-10T04:23:11.181Z",
+        "updatedAt": null,
+        "position": 65536.0,
+        "name": "Specification",
+        "showOnFrontOfCard": true,
+        "baseCustomFieldGroupId": "1838314588785870118",
+        "customFieldGroupId": null
+    });
+
+    let field: CustomField = serde_json::from_value(api_json).unwrap();
+    assert_eq!(field.name, "Specification");
+    assert!(field.show_on_front_of_card);
+    assert!(field.custom_field_group_id.is_none());
+    assert_eq!(
+        field.base_custom_field_group_id,
+        Some("1838314588785870118".to_string())
+    );
+}
+
+#[test]
+fn custom_field_belonging_to_card_group_deserializes() {
+    let api_json = serde_json::json!({
+        "id": "1838307535082226873",
+        "createdAt": "2026-08-10T04:08:55.229Z",
+        "updatedAt": null,
+        "position": 65536.0,
+        "name": "Specification",
+        "showOnFrontOfCard": false,
+        "baseCustomFieldGroupId": null,
+        "customFieldGroupId": "1838305759222301878"
+    });
+
+    let field: CustomField = serde_json::from_value(api_json).unwrap();
+    assert!(!field.show_on_front_of_card);
+    assert_eq!(
+        field.custom_field_group_id,
+        Some("1838305759222301878".to_string())
+    );
+    assert!(field.base_custom_field_group_id.is_none());
+}
+
+#[test]
+fn custom_field_value_roundtrip_camel_case() {
+    let value = CustomFieldValue {
+        id: "1".to_string(),
+        card_id: "2".to_string(),
+        custom_field_group_id: "3".to_string(),
+        custom_field_id: "4".to_string(),
+        content: "specs/2026-08-06-codex-design.html".to_string(),
+        created_at: "2026-08-10T04:30:00.000Z".to_string(),
+        updated_at: None,
+    };
+
+    let json = serde_json::to_value(&value).unwrap();
+    assert_eq!(json["cardId"], "2");
+    assert_eq!(json["customFieldGroupId"], "3");
+    assert_eq!(json["customFieldId"], "4");
+    assert_eq!(json["content"], "specs/2026-08-06-codex-design.html");
+    assert!(json.get("card_id").is_none(), "should use camelCase");
+
+    let deserialized: CustomFieldValue = serde_json::from_value(json).unwrap();
+    assert_eq!(deserialized, value);
+}
+
+#[test]
+fn custom_field_trimmed_columns_match_wire_format() {
+    let fields: Vec<&str> = CustomField::trimmed_columns()
+        .iter()
+        .map(|(f, _)| *f)
+        .collect();
+    assert_eq!(
+        fields,
+        vec!["id", "name", "showOnFrontOfCard", "position"],
+        "trimmed columns must use wire spelling, never display labels"
+    );
+
+    let group_fields: Vec<&str> = CustomFieldGroup::trimmed_columns()
+        .iter()
+        .map(|(f, _)| *f)
+        .collect();
+    assert_eq!(
+        group_fields,
+        vec!["id", "name", "cardId", "boardId", "position"]
+    );
+
+    let value_fields: Vec<&str> = CustomFieldValue::trimmed_columns()
+        .iter()
+        .map(|(f, _)| *f)
+        .collect();
+    assert_eq!(value_fields, vec!["id", "customFieldId", "content"]);
+
+    let base_fields: Vec<&str> = BaseCustomFieldGroup::trimmed_columns()
+        .iter()
+        .map(|(f, _)| *f)
+        .collect();
+    assert_eq!(base_fields, vec!["id", "name", "projectId"]);
+}
+
+#[test]
+fn update_custom_field_omits_unset_fields() {
+    let params = UpdateCustomField {
+        name: Some("Spec".to_string()),
+        show_on_front_of_card: None,
+    };
+    let json = serde_json::to_value(&params).unwrap();
+    assert_eq!(json["name"], "Spec");
+    assert!(
+        json.get("showOnFrontOfCard").is_none(),
+        "unset must be omitted, not sent as null"
+    );
+}
+
+/// "Set to false" and "leave unchanged" must stay distinguishable — an
+/// explicit `false` has to reach the wire.
+#[test]
+fn update_custom_field_sends_explicit_false() {
+    let params = UpdateCustomField {
+        name: None,
+        show_on_front_of_card: Some(false),
+    };
+    let json = serde_json::to_value(&params).unwrap();
+    assert_eq!(json["showOnFrontOfCard"], false);
+    assert!(json.get("name").is_none());
+}
+
+#[test]
+fn update_custom_field_group_omits_unset_name() {
+    let params = UpdateCustomFieldGroup { name: None };
+    let json = serde_json::to_value(&params).unwrap();
+    assert_eq!(json.as_object().unwrap().len(), 0);
 }

--- a/crates/plnk-core/src/models/tests.rs
+++ b/crates/plnk-core/src/models/tests.rs
@@ -819,7 +819,15 @@ fn custom_field_trimmed_columns_match_wire_format() {
         .collect();
     assert_eq!(
         group_fields,
-        vec!["id", "name", "cardId", "boardId", "position"]
+        vec![
+            "id",
+            "name",
+            "baseCustomFieldGroupId",
+            "cardId",
+            "boardId",
+            "position"
+        ],
+        "an adopted group's name is null, so the base group id must survive trimming"
     );
 
     let value_fields: Vec<&str> = CustomFieldValue::trimmed_columns()

--- a/crates/plnk-core/tests/custom_fields.rs
+++ b/crates/plnk-core/tests/custom_fields.rs
@@ -1,0 +1,440 @@
+//! Wire-level tests for the custom field API traits.
+//!
+//! These pin the routes and payloads that Planka's published `OpenAPI` spec gets
+//! wrong, and the idempotent-clear behaviour that deliberately departs from the
+//! crate's usual error handling.
+
+use plnk_core::api::{CardCustomFieldApi, CustomFieldApi, CustomFieldGroupApi, PlankaClientV1};
+use plnk_core::client::HttpClient;
+use plnk_core::error::PlankaError;
+use plnk_core::models::{UpdateCustomField, UpdateCustomFieldGroup};
+use serde_json::json;
+use url::Url;
+use wiremock::matchers::{body_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn client_for(server: &MockServer) -> PlankaClientV1 {
+    let base_url = Url::parse(&server.uri()).unwrap();
+    let http = HttpClient::new(base_url, "test-api-key").unwrap();
+    PlankaClientV1::new(http)
+}
+
+/// The composite value segment carries no `$`. Planka's published spec writes
+/// `customFieldId:${customFieldId}`; sending the literal `$` returns a 400.
+const VALUE_PATH: &str =
+    "/api/cards/card-1/custom-field-values/customFieldGroupId:group-1:customFieldId:field-1";
+
+fn value_body() -> serde_json::Value {
+    json!({
+        "item": {
+            "id": "value-1",
+            "cardId": "card-1",
+            "customFieldGroupId": "group-1",
+            "customFieldId": "field-1",
+            "content": "specs/x.html",
+            "createdAt": "2026-08-10T00:00:00Z",
+            "updatedAt": null
+        }
+    })
+}
+
+#[tokio::test]
+async fn set_field_value_uses_composite_path_without_dollar_sign() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path(VALUE_PATH))
+        .and(body_json(json!({"content": "specs/x.html"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(value_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let value = client_for(&server)
+        .set_field_value("card-1", "group-1", "field-1", "specs/x.html")
+        .await
+        .unwrap();
+
+    assert_eq!(value.id, "value-1");
+    assert_eq!(value.content, "specs/x.html");
+}
+
+/// The live DELETE route is plural. The spec's singular `custom-field-value`
+/// does not exist — mounting only the plural route proves we target it.
+#[tokio::test]
+async fn clear_field_value_targets_plural_route() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path(VALUE_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(value_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    client_for(&server)
+        .clear_field_value("card-1", "group-1", "field-1")
+        .await
+        .unwrap();
+}
+
+/// Clearing is "ensure unset", so an already-unset value is a success.
+#[tokio::test]
+async fn clear_field_value_swallows_404() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path(VALUE_PATH))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "code": "E_NOT_FOUND",
+            "message": "Custom field value not found"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let result = client_for(&server)
+        .clear_field_value("card-1", "group-1", "field-1")
+        .await;
+
+    assert!(result.is_ok(), "an already-unset value must clear cleanly");
+}
+
+/// Only 404 is swallowed — every other status stays fatal.
+#[tokio::test]
+async fn clear_field_value_propagates_non_404_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path(VALUE_PATH))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "code": "E_INTERNAL_SERVER_ERROR"
+        })))
+        .mount(&server)
+        .await;
+
+    let result = client_for(&server)
+        .clear_field_value("card-1", "group-1", "field-1")
+        .await;
+
+    assert!(
+        matches!(result, Err(PlankaError::ApiError { status: 500, .. })),
+        "a 500 must not be treated as an already-unset value, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_card_field_group_sends_base_id_and_never_a_name() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/cards/card-1/custom-field-groups"))
+        .and(body_json(json!({
+            "baseCustomFieldGroupId": "base-1",
+            "position": 65536.0
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "item": {
+                "id": "group-1",
+                "name": null,
+                "boardId": null,
+                "cardId": "card-1",
+                "baseCustomFieldGroupId": "base-1",
+                // The server repositions when a sibling holds the slot; the
+                // echo is deliberately different from what we sent.
+                "position": 81920.0,
+                "createdAt": "2026-08-10T00:00:00Z",
+                "updatedAt": null
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let group = client_for(&server)
+        .create_card_field_group("card-1", Some("base-1"), None)
+        .await
+        .unwrap();
+
+    assert!(group.name.is_none());
+    assert_eq!(group.base_custom_field_group_id, Some("base-1".to_string()));
+    assert!(
+        (group.position - 81920.0).abs() < f64::EPSILON,
+        "the server's position must be taken as authoritative, not the request's"
+    );
+}
+
+#[tokio::test]
+async fn create_card_field_group_sends_name_and_never_a_base_id() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/cards/card-1/custom-field-groups"))
+        .and(body_json(json!({"name": "Ad-hoc", "position": 65536.0})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "item": {
+                "id": "group-2",
+                "name": "Ad-hoc",
+                "boardId": null,
+                "cardId": "card-1",
+                "baseCustomFieldGroupId": null,
+                "position": 65536.0,
+                "createdAt": "2026-08-10T00:00:00Z",
+                "updatedAt": null
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let group = client_for(&server)
+        .create_card_field_group("card-1", None, Some("Ad-hoc"))
+        .await
+        .unwrap();
+
+    assert_eq!(group.name, Some("Ad-hoc".to_string()));
+    assert!(group.base_custom_field_group_id.is_none());
+}
+
+#[tokio::test]
+async fn create_card_field_group_without_base_or_name_is_a_validation_error() {
+    let server = MockServer::start().await;
+
+    let result = client_for(&server)
+        .create_card_field_group("card-1", None, None)
+        .await;
+
+    assert!(
+        matches!(result, Err(PlankaError::MissingRequiredOption { .. })),
+        "expected a validation error and no request, got {result:?}"
+    );
+}
+
+/// Base groups live behind their own routes: creating a field on one uses
+/// `/api/base-custom-field-groups/{id}/custom-fields`.
+#[tokio::test]
+async fn create_field_routes_by_group_kind() {
+    let server = MockServer::start().await;
+
+    let field = |group_key: &str, base: Option<&str>| {
+        json!({
+            "item": {
+                "id": "field-1",
+                "name": "Specification",
+                "position": 65536.0,
+                "showOnFrontOfCard": true,
+                "customFieldGroupId": if base.is_some() { serde_json::Value::Null }
+                                      else { json!(group_key) },
+                "baseCustomFieldGroupId": base.map_or(serde_json::Value::Null, |b| json!(b)),
+                "createdAt": "2026-08-10T00:00:00Z",
+                "updatedAt": null
+            }
+        })
+    };
+
+    Mock::given(method("POST"))
+        .and(path("/api/base-custom-field-groups/base-1/custom-fields"))
+        .and(body_json(json!({
+            "name": "Specification",
+            "position": 65536.0,
+            "showOnFrontOfCard": true
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(field("base-1", Some("base-1"))))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/custom-field-groups/group-1/custom-fields"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(field("group-1", None)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let from_base = client
+        .create_field("base-1", true, "Specification", true)
+        .await
+        .unwrap();
+    assert!(from_base.show_on_front_of_card);
+    assert_eq!(
+        from_base.base_custom_field_group_id,
+        Some("base-1".to_string())
+    );
+
+    let from_group = client
+        .create_field("group-1", false, "Specification", true)
+        .await
+        .unwrap();
+    assert_eq!(
+        from_group.custom_field_group_id,
+        Some("group-1".to_string())
+    );
+}
+
+/// A base group's fields are readable only from the projects list — no board
+/// snapshot and no by-id base-group route exposes them.
+#[tokio::test]
+async fn list_fields_for_base_group_reads_the_projects_list() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/projects"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [],
+            "included": {
+                "baseCustomFieldGroups": [
+                    {
+                        "id": "base-1",
+                        "name": "Documentation",
+                        "projectId": "project-1",
+                        "createdAt": "2026-08-10T00:00:00Z",
+                        "updatedAt": null
+                    }
+                ],
+                "customFields": [
+                    {
+                        "id": "field-1",
+                        "name": "Specification",
+                        "position": 65536.0,
+                        "showOnFrontOfCard": true,
+                        "customFieldGroupId": null,
+                        "baseCustomFieldGroupId": "base-1",
+                        "createdAt": "2026-08-10T00:00:00Z",
+                        "updatedAt": null
+                    },
+                    {
+                        "id": "field-2",
+                        "name": "Belongs elsewhere",
+                        "position": 65536.0,
+                        "showOnFrontOfCard": false,
+                        "customFieldGroupId": null,
+                        "baseCustomFieldGroupId": "base-other",
+                        "createdAt": "2026-08-10T00:00:00Z",
+                        "updatedAt": null
+                    }
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let fields = client_for(&server)
+        .list_fields("base-1", true)
+        .await
+        .unwrap();
+
+    assert_eq!(fields.len(), 1, "must not leak other base groups' fields");
+    assert_eq!(fields[0].id, "field-1");
+}
+
+#[tokio::test]
+async fn list_fields_for_unknown_base_group_is_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/projects"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [],
+            "included": {"baseCustomFieldGroups": [], "customFields": []}
+        })))
+        .mount(&server)
+        .await;
+
+    let result = client_for(&server).list_fields("missing", true).await;
+
+    assert!(
+        matches!(result, Err(PlankaError::NotFound { .. })),
+        "an absent base group must be a not-found, not an empty list; got {result:?}"
+    );
+}
+
+/// Base groups have their own PATCH and DELETE routes. `PATCH
+/// /api/custom-field-groups/{baseId}` returns a real 404.
+#[tokio::test]
+async fn base_group_update_and_delete_use_base_routes() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/api/base-custom-field-groups/base-1"))
+        .and(body_json(json!({"name": "Docs"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "item": {
+                "id": "base-1",
+                "name": "Docs",
+                "projectId": "project-1",
+                "createdAt": "2026-08-10T00:00:00Z",
+                "updatedAt": "2026-08-10T01:00:00Z"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/api/base-custom-field-groups/base-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "item": {
+                "id": "base-1",
+                "name": "Docs",
+                "projectId": "project-1",
+                "createdAt": "2026-08-10T00:00:00Z",
+                "updatedAt": null
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let updated = client
+        .update_base_field_group(
+            "base-1",
+            UpdateCustomFieldGroup {
+                name: Some("Docs".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.name, "Docs");
+
+    client.delete_base_field_group("base-1").await.unwrap();
+}
+
+/// "Leave unchanged" and "set false" must stay distinguishable on the wire.
+#[tokio::test]
+async fn update_field_sends_explicit_false_for_show_on_front() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/api/custom-fields/field-1"))
+        .and(body_json(json!({"showOnFrontOfCard": false})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "item": {
+                "id": "field-1",
+                "name": "Specification",
+                "position": 65536.0,
+                "showOnFrontOfCard": false,
+                "customFieldGroupId": "group-1",
+                "baseCustomFieldGroupId": null,
+                "createdAt": "2026-08-10T00:00:00Z",
+                "updatedAt": null
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let field = client_for(&server)
+        .update_field(
+            "field-1",
+            UpdateCustomField {
+                name: None,
+                show_on_front_of_card: Some(false),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(!field.show_on_front_of_card);
+}

--- a/docs/cli/cards.md
+++ b/docs/cli/cards.md
@@ -161,6 +161,21 @@ plnk card assignee add <cardId> <userId>
 plnk card assignee remove <cardId> <userId>
 ```
 
+### Custom field values
+
+```bash
+plnk card field list <cardId>
+plnk card field set <cardId> --group <id|name> --field <id|name> --value "specs/design.html"
+plnk card field clear <cardId> --group <id|name> --field <id|name>
+```
+
+`--group` and `--field` accept an ID or a name, resolving through the card's attached groups
+(and through the base group when the card's group was adopted from a template). Values are
+capped at 512 characters and cannot be empty; `clear` is idempotent.
+
+See [Custom fields](custom-fields.md) for the full model, including how to define a reusable
+field template on a project and adopt it onto a card.
+
 ## Examples
 
 ```bash

--- a/docs/cli/custom-fields.md
+++ b/docs/cli/custom-fields.md
@@ -1,0 +1,207 @@
+# Custom Fields
+
+Custom fields are the only place in Planka where a card can carry **structured, named metadata** rather than free prose. A spec URL, an external ticket id, an owner ruling date — anything that is a named attribute — has nowhere else to live except buried in a description.
+
+Three resources are involved:
+
+- **`plnk field-group`** — the groups that hold fields
+- **`plnk field`** — the named slots inside a group
+- **`plnk card field`** — the values a card stores for those slots
+
+## The model
+
+```
+project ── base custom field group ── custom field      (the reusable template)
+                                          │
+board  ─────── custom field group ── custom field       (board-local definition)
+                                          │
+card   ─────── custom field group ── custom field       (card-local definition)
+   └────────── custom field value   (card × group × field → string)
+```
+
+A group on a **project** is a *base group*: a reusable template. A card adopts one by creating a card-level group that carries `baseCustomFieldGroupId`. A group created without that id is a one-off, local to whatever it hangs from.
+
+Two consequences of adopting a template are worth knowing before you script against this:
+
+- An adopted card group has **`name: null`**. Its display name lives on the base group.
+- An adopted card group carries **no fields of its own**. The fields belong to the base group.
+
+`plnk` hides both when you use names — `--group Documentation` resolves through the base group — but they show up plainly in JSON output.
+
+## What custom fields are and are not
+
+They make a value **visible and structured**. They do not make it **queryable**:
+
+- `content` is capped at **512 characters**, so a card governed by a dozen documents cannot list them all in one field.
+- **There is no server-side filter on custom field values.** No Planka endpoint filters cards by field value. Filtering means pulling a snapshot and filtering client-side, exactly as if the value lived in the description.
+
+Use them for the one or two canonical pointers, not as a general-purpose index.
+
+## Field groups
+
+### List groups
+
+```bash
+plnk field-group list --project <projectId>   # base groups (the templates)
+plnk field-group list --board <boardId>       # groups on a board
+plnk field-group list --card <cardId>         # groups on a card
+plnk field-groups --card <cardId>             # alias
+```
+
+`--project` returns base groups; `--board` and `--card` return ordinary groups. These are different types with different columns.
+
+### Find groups by name
+
+```bash
+plnk field-group find --project <projectId> --name "Documentation"
+plnk field-group find --card <cardId> --name "Docs"
+```
+
+### Get a group
+
+```bash
+plnk field-group get <groupId>
+```
+
+Accepts either kind of ID. Base groups and ordinary groups live behind different routes, so `get` tries the ordinary route first and falls back to the base route.
+
+### Create a group
+
+```bash
+# A reusable template on a project
+plnk field-group create --project <projectId> --name "Documentation"
+
+# A board-local group
+plnk field-group create --board <boardId> --name "Properties"
+
+# Adopt a template onto a card
+plnk field-group create --card <cardId> --base <baseGroupId>
+
+# A one-off group on a card
+plnk field-group create --card <cardId> --name "Ad-hoc"
+```
+
+On `--card`, exactly one of `--base` or `--name` is required. Passing neither exits `2`.
+
+Attaching a base group to every card on a board is a scripted loop, not a CLI primitive.
+
+### Update and delete
+
+```bash
+plnk field-group update <groupId> --name "Docs"
+plnk field-group delete <groupId> --yes
+```
+
+## Fields
+
+### List and find fields
+
+```bash
+plnk field list --base-group <baseGroupId>
+plnk field list --group <groupId>
+plnk fields --base-group <baseGroupId>          # alias
+
+plnk field find --base-group <baseGroupId> --name "Spec"
+```
+
+Asking an **adopted** card group for its fields returns nothing — the fields belong to its base group. Ask the base group instead.
+
+### Create a field
+
+```bash
+plnk field create --base-group <baseGroupId> --name "Specification" --show-on-front
+plnk field create --group <groupId> --name "Implementation Plan"
+```
+
+`--show-on-front` controls whether the value appears on the front of the card in the Planka web UI. It is off by default, matching Planka. It is the difference between a field a human sees at a glance and one only a script reads.
+
+### Update and delete
+
+```bash
+plnk field update <fieldId> --name "Spec"
+plnk field update <fieldId> --show-on-front false
+plnk field delete <fieldId> --yes
+```
+
+On `update`, `--show-on-front` takes an explicit `true` or `false`, because "leave unchanged" and "set to false" have to stay distinguishable.
+
+## Card field values
+
+```bash
+plnk card field list <cardId>
+plnk card field set <cardId> --group <id|name> --field <id|name> --value "specs/design.html"
+plnk card field clear <cardId> --group <id|name> --field <id|name>
+```
+
+`--group` and `--field` accept an **ID or a name**, following the precedent set by `card label add`. Names resolve within the card's own attached groups, reaching through to the base group where needed. Use an ID to avoid ambiguity.
+
+Resolution follows the house three-tier match — exact case-sensitive, then case-insensitive, then substring — stopping at the first tier with results:
+
+- no match → `ResourceNotFound`, exit `4`
+- more than one match in the winning tier → validation error naming every candidate, exit `2`
+
+### Value rules
+
+| Situation | Result |
+|---|---|
+| value longer than 512 characters | exit `2`, no request sent |
+| empty value | exit `2`, message points at `card field clear` |
+| clearing an already-unset value | exit `0` — clearing is idempotent |
+
+There is no "set to empty": Planka rejects an empty string outright, so clearing is a distinct operation rather than a value you can assign.
+
+## Worked example
+
+Point a card at the documents that govern it:
+
+```bash
+# 1. Define the template once, on the project
+plnk field-group create --project 123 --name "Documentation"
+# → returns the base group id, e.g. 777
+
+# 2. Add fields to the template
+plnk field create --base-group 777 --name "Specification" --show-on-front
+plnk field create --base-group 777 --name "Implementation Plan" --show-on-front
+
+# 3. Adopt the template onto a card
+plnk field-group create --card 1234 --base 777
+
+# 4. Fill in the values — by name, not id
+plnk card field set 1234 --group "Documentation" --field "Specification" \
+                         --value "specs/2026-08-06-design.html"
+plnk card field set 1234 --group "Documentation" --field "Implementation Plan" \
+                         --value "specs/2026-08-06-plan.md"
+
+# 5. Read them back
+plnk card field list 1234 --output json
+
+# 6. Clear one
+plnk card field clear 1234 --group "Documentation" --field "Specification"
+```
+
+## JSON output
+
+Output is a strict serde projection — wire spelling and nulls intact. An adopted group is recognisable by its null `name` and non-null `baseCustomFieldGroupId`:
+
+```bash
+plnk field-group list --card 1234 --output json
+```
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "1838340027382236525",
+      "name": null,
+      "baseCustomFieldGroupId": "1838336514124154209",
+      "cardId": "1838330705323492688",
+      "boardId": null,
+      "position": 65536.0
+    }
+  ],
+  "meta": { "count": 1 }
+}
+```
+
+Add `--full` for every field, including `createdAt` and `updatedAt`.

--- a/docs/cli/examples.md
+++ b/docs/cli/examples.md
@@ -105,6 +105,69 @@ $ plnk card get 1756505635064644838 --output markdown
 
 Add `--full` for the complete field set (description, timestamps, creator, subscription state).
 
+## Pointing a card at its documents
+
+Custom fields are the only structured, named metadata a card can carry. This defines a
+reusable template once, adopts it onto a card, and fills it in by name.
+
+```bash
+# Define the template on the project, once
+BASE=$(plnk field-group create --project 123 --name "Documentation" \
+         --output json | jq -r .data.id)
+
+# Give it two named slots, both visible on the card face in the web UI
+plnk field create --base-group "$BASE" --name "Specification" --show-on-front
+plnk field create --base-group "$BASE" --name "Implementation Plan" --show-on-front
+
+# Adopt the template onto a card
+plnk field-group create --card 1234 --base "$BASE"
+
+# Fill in the values by name — resolution reaches through to the base group,
+# so this works even though the adopted group's own name is null
+plnk card field set 1234 --group "Documentation" --field "Specification" \
+                         --value "specs/2026-08-06-design.html"
+plnk card field set 1234 --group "Documentation" --field "Implementation Plan" \
+                         --value "specs/2026-08-06-plan.md"
+
+# Read them back
+plnk card field list 1234 --output json
+```
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "1838340035317859694",
+      "customFieldId": "1838338046462788967",
+      "content": "specs/2026-08-06-design.html"
+    },
+    {
+      "id": "1838340251232241010",
+      "customFieldId": "1838338049474299240",
+      "content": "specs/2026-08-06-plan.md"
+    }
+  ],
+  "meta": { "count": 2 }
+}
+```
+
+Values are capped at 512 characters and cannot be empty — clearing is a separate
+operation, and it is idempotent:
+
+```bash
+plnk card field clear 1234 --group "Documentation" --field "Specification"   # exit 0
+plnk card field clear 1234 --group "Documentation" --field "Specification"   # exit 0 again
+```
+
+There is no server-side filter on custom field values. Filtering by value means
+pulling a snapshot and filtering locally:
+
+```bash
+plnk card snapshot 1234 --output json \
+  | jq '.included.customFieldValues[] | select(.content | test("codex"))'
+```
+
 ## Exit codes for script branching
 
 Every command exits with a typed status code so shell scripts can branch without parsing stderr.

--- a/docs/cli/grammar.md
+++ b/docs/cli/grammar.md
@@ -12,7 +12,7 @@ Every command fits this form. No verb-first commands, no hidden actions — the 
 
 ## Resources
 
-`project`, `board`, `list`, `card`, `task`, `comment`, `label`, `attachment`, `membership`, `user`, `auth`
+`project`, `board`, `list`, `card`, `task`, `comment`, `label`, `field-group`, `field`, `attachment`, `membership`, `user`, `auth`
 
 Each has its own per-resource docs in [`docs/cli/`](.).
 
@@ -26,8 +26,11 @@ project
         task
         comment
         attachment
+        custom field group ── custom field ── value
     label
+    custom field group ── custom field
   membership
+  base custom field group ── custom field
 ```
 
 All scoped queries follow this hierarchy. You can't list cards without a list (or board / project for `find`). You can't list tasks without a card. Sole exception: `project find` is unscoped because projects are the root.
@@ -149,6 +152,8 @@ plnk cards --board <id>            # → plnk card list --board <id>
 plnk tasks --card <id>             # → plnk task list --card <id>
 plnk comments --card <id>          # → plnk comment list --card <id>
 plnk labels --board <id>           # → plnk label list --board <id>
+plnk field-groups --card <id>      # → plnk field-group list --card <id>
+plnk fields --base-group <id>      # → plnk field list --base-group <id>
 ```
 
 ## Stdout vs stderr

--- a/skills/plnk-cli/SKILL.md
+++ b/skills/plnk-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plnk-cli
-description: Use this skill when the user wants to inspect or manage Planka projects, boards, lists, cards, tasks, comments, labels, attachments, memberships, users, or authentication with the plnk CLI.
+description: Use this skill when the user wants to inspect or manage Planka projects, boards, lists, cards, tasks, comments, labels, custom fields (field groups, fields, card field values), attachments, memberships, users, or authentication with the plnk CLI.
 ---
 
 # plnk-cli
@@ -14,7 +14,7 @@ Use this skill when the user wants to:
 - inspect Planka projects, boards, lists, cards, tasks, comments, labels, attachments, memberships, or users
 - create, update, move, archive, unarchive, or delete Planka resources
 - find cards, lists, boards, or labels by name/title
-- add comments, tasks, assignees, labels, or attachments to cards
+- add comments, tasks, assignees, labels, custom field values, or attachments to cards
 - understand or debug `plnk` command behavior
 
 ## Core Rules
@@ -43,8 +43,11 @@ project
         task
         comment
         attachment
+        custom field group ── custom field ── value
     label
+    custom field group ── custom field
   membership
+  base custom field group ── custom field   (reusable template)
 ```
 
 Implications:
@@ -55,6 +58,9 @@ Implications:
 - `card find` requires exactly one of `--list`, `--board`, or `--project`.
 - tasks and comments live under cards
 - labels live under boards
+- `field-group list` requires exactly one of `--project`, `--board`, or `--card`
+- `field list` requires exactly one of `--group` or `--base-group`
+- custom field *values* live under cards: `card field list|set|clear`
 
 ## Default Operating Procedure
 
@@ -140,6 +146,17 @@ and errors like:
 
 - `get` requires an ID. Never use `get` with a name.
 - `find` returns collections, including zero or many matches.
+- Custom fields have three surfaces — do not conflate them:
+  - `plnk field-group` — the groups (project-level ones are reusable templates)
+  - `plnk field` — the named slots inside a group
+  - `plnk card field` — the values a card stores
+- A card group adopted from a template has `name: null` and **no fields of its own** — its
+  fields belong to the base group. `field list --group <adoptedId>` returning nothing is
+  correct; ask `field list --base-group <baseId>`. See `references/api-quirks.md`.
+- `card field set/clear` accept an ID **or a name** for `--group` and `--field`, resolving
+  through the base group. Values are capped at 512 chars, cannot be empty, and `clear` is
+  idempotent.
+- There is no server-side filter by custom field value — filter a snapshot locally.
 - There is no standalone `get` for `task`, `comment`, or `label`.
   - use `task list --card <cardId>`
   - use `comment list --card <cardId>`
@@ -216,6 +233,7 @@ Resource docs:
 - `../../docs/cli/tasks.md`
 - `../../docs/cli/comments.md`
 - `../../docs/cli/labels.md`
+- `../../docs/cli/custom-fields.md`
 - `../../docs/cli/attachments.md`
 - `../../docs/cli/memberships.md`
 - `../../docs/cli/users.md`

--- a/skills/plnk-cli/references/api-quirks.md
+++ b/skills/plnk-cli/references/api-quirks.md
@@ -18,13 +18,64 @@ plnk board snapshot <boardId> --output json # whole board (labels under included
 
 The parent listing paths use proper GET endpoints and don't mutate `updatedAt`.
 
+## Custom fields: adopted groups have no name and no fields of their own
+
+The single most confusing part of the custom field model.
+
+A card adopts a project-level template (a *base group*) by creating a card-level group that
+carries `baseCustomFieldGroupId`. That adopted group has:
+
+- **`name: null`** — its display name lives on the base group
+- **no fields of its own** — `GET /api/custom-field-groups/{adoptedId}` returns
+  `included.customFields: []`, because the fields belong to the base group
+
+So `plnk field list --group <adoptedCardGroupId>` correctly returns **zero** fields. Ask the
+base group instead:
+
+```bash
+plnk field-group list --card <cardId> --output json   # note name: null, baseCustomFieldGroupId set
+plnk field list --base-group <baseGroupId>            # the fields actually live here
+```
+
+`plnk card field set/clear` hides all of this — `--group Documentation` resolves through the
+base group — so prefer names there and only drop to IDs to break ambiguity.
+
+## Custom fields: base groups are only partly routed
+
+There is **no `GET /api/base-custom-field-groups/{id}`**. That path falls through to the Planka
+SPA and returns HTML with HTTP `200` — worse than a 404, since a JSON client fails with a parse
+error rather than a clean not-found. `PATCH` and `DELETE` on the same prefix *do* exist.
+
+Base groups are readable only through `GET /api/projects` or `GET /api/projects/{id}`, under
+`included.baseCustomFieldGroups`. The board snapshot has no `baseCustomFieldGroups` key at all,
+and its `included.customFields` covers only board- and card-level group fields.
+
+`plnk field-group get <id>` handles this by falling back to the base route, so scripts can pass
+any group ID without tracking its kind.
+
+## Custom fields: value rules
+
+- `content` is capped at **512 characters**. `plnk` rejects over-length client-side with exit
+  `2` and sends no request.
+- **Empty strings are rejected by the server.** There is no "set to empty" — clearing is
+  `plnk card field clear`, which maps to a DELETE. `plnk` exits `2` on `--value ""` and says so.
+- Clearing is **idempotent**: an already-unset value exits `0`.
+- **No endpoint filters cards by custom field value.** Do not look for one. Filter client-side:
+
+```bash
+plnk card snapshot <cardId> --output json \
+  | jq '.included.customFieldValues[] | select(.content | test("pattern"))'
+```
+
+- The server may **rewrite a group's `position`** on create. Never assert the echoed value.
+
 ## Board snapshot pattern
 
 Many resources are not directly listable. Instead, the CLI fetches a parent "snapshot" that includes nested data:
 
 - `GET /api/boards/{id}` returns `included.lists`, `included.cards`, `included.labels`, `included.boardMemberships`
-- `GET /api/cards/{id}` returns `included.tasks`, `included.taskLists`, `included.cardLabels`, `included.cardMemberships`, `included.attachments`
-- `GET /api/projects/{id}` returns `included.boards`, `included.projectManagers`
+- `GET /api/cards/{id}` returns `included.tasks`, `included.taskLists`, `included.cardLabels`, `included.cardMemberships`, `included.attachments`, `included.customFieldGroups`, `included.customFields`, `included.customFieldValues`
+- `GET /api/projects/{id}` returns `included.boards`, `included.projectManagers`, `included.baseCustomFieldGroups`, `included.customFields`
 
 This means listing labels on a board actually fetches the entire board snapshot. Listing tasks on a card fetches the entire card snapshot. The CLI extracts what it needs.
 

--- a/skills/plnk-cli/references/commands.md
+++ b/skills/plnk-cli/references/commands.md
@@ -33,6 +33,11 @@ This file is optimized for agent lookup. When using it from Pi:
 | add a comment to a card | `plnk comment create --card <cardId> --text <text>` |
 | list labels on a board | `plnk label list --board <boardId>` |
 | apply/remove label on card | `plnk card label add <cardId> <labelId>` / `plnk card label remove <cardId> <labelId>` |
+| list custom field groups on a card | `plnk field-group list --card <cardId>` |
+| define a reusable field template | `plnk field-group create --project <projectId> --name <name>` then `plnk field create --base-group <groupId> --name <name>` |
+| attach a template to a card | `plnk field-group create --card <cardId> --base <baseGroupId>` |
+| set/clear a custom field value | `plnk card field set <cardId> --group <id\|name> --field <id\|name> --value <text>` / `plnk card field clear <cardId> --group <id\|name> --field <id\|name>` |
+| read a card's custom field values | `plnk card field list <cardId>` |
 | list assignees on a card | `plnk card assignee list <cardId>` |
 | add/remove assignee | `plnk card assignee add <cardId> <userId>` / `plnk card assignee remove <cardId> <userId>` |
 | list/upload/download attachments | `plnk attachment list --card <cardId>` / `plnk attachment upload --card <cardId> <file>` / `plnk attachment download <attachmentId> --card <cardId>` |
@@ -260,6 +265,62 @@ Alias: `plnk labels --board <boardId>`
 
 `berry-red`, `pumpkin-orange`, `light-mud`, `sunset-orange`, `rain-blue`, `lagoon-blue`, `sky-blue`, `midnight-blue`, `concrete-gray`, `bright-moss`, `dark-granite`, `pink-tulip`
 
+## Field Group
+
+```bash
+plnk field-group list --project <projectId>   # base groups (reusable templates)
+plnk field-group list --board <boardId>
+plnk field-group list --card <cardId>
+plnk field-group find --project <projectId> --name <name>
+plnk field-group get <groupId>
+plnk field-group create --project <projectId> --name <name>   # a template
+plnk field-group create --board <boardId> --name <name>
+plnk field-group create --card <cardId> --base <baseGroupId>  # adopt a template
+plnk field-group create --card <cardId> --name <name>         # one-off group
+plnk field-group update <groupId> --name <name>
+plnk field-group delete <groupId> [--yes]
+```
+
+Alias: `plnk field-groups --project|--board|--card <id>`
+
+- `--project`, `--board`, `--card` are mutually exclusive and one is required on `list`, `find` and `create`.
+- `--project` returns **base groups** (a different type with different columns than board/card groups). Do not expect one shape.
+- On `create --card`, exactly one of `--base` or `--name`. Neither exits `2`.
+- `get`, `update` and `delete` accept either kind of ID and fall back to the base-group route automatically.
+
+## Field
+
+```bash
+plnk field list --base-group <baseGroupId>
+plnk field list --group <groupId>
+plnk field find --base-group <baseGroupId> --name <name>
+plnk field create --base-group <baseGroupId> --name <name> [--show-on-front]
+plnk field create --group <groupId> --name <name>
+plnk field update <fieldId> [--name <name>] [--show-on-front true|false]
+plnk field delete <fieldId> [--yes]
+```
+
+Alias: `plnk fields --group|--base-group <id>`
+
+- `--group` and `--base-group` are mutually exclusive and one is required on `list`, `find` and `create`.
+- **Asking an adopted card group for its fields returns nothing.** Its fields belong to the base group — ask `--base-group <baseGroupId>` instead. This is not a bug.
+- `--show-on-front` makes the value visible on the card face in the Planka web UI. Off by default.
+
+## Card Field Values
+
+```bash
+plnk card field list <cardId>
+plnk card field set <cardId> --group <id|name> --field <id|name> --value <text>
+plnk card field clear <cardId> --group <id|name> --field <id|name>
+```
+
+- `--group` and `--field` accept an **ID or a name**, like `card label add`. Names resolve within the card's own groups and reach through to the base group. Use an ID to avoid ambiguity.
+- Ambiguous name → exit `2` naming every candidate. No match → exit `4`.
+- Values are capped at **512 characters**; over-length exits `2` with no request sent.
+- **Empty values are rejected** (exit `2`). There is no "set to empty" — use `card field clear`.
+- `clear` is **idempotent**: clearing an already-unset value exits `0`.
+- **There is no server-side filter by field value.** To filter, pull a snapshot and filter locally.
+
 ## Attachment
 
 ```bash
@@ -300,6 +361,8 @@ All aliases are hidden from `--help` and produce identical output to their canon
 | `plnk tasks --card <id>` | `plnk task list --card <id>` |
 | `plnk comments --card <id>` | `plnk comment list --card <id>` |
 | `plnk labels --board <id>` | `plnk label list --board <id>` |
+| `plnk field-groups --card <id>` | `plnk field-group list --card <id>` |
+| `plnk fields --base-group <id>` | `plnk field list --base-group <id>` |
 
 ## Global Flags
 


### PR DESCRIPTION
Adds custom field support across the SDK and CLI: three new resources (`field-group`, `field`, `card field`) with full CRUD, ID-or-name resolution following the house three-tier match, and client-side validation of Planka's 512-character cap.

Name resolution reaches through base groups — a card group adopted from a template has a null name *and* no fields of its own, so both the group name and its field names resolve via `baseCustomFieldGroupId`. Every endpoint was verified against a live Planka server, and the wire quirks found along the way (several contradicting Planka's published OpenAPI spec, including a base-group GET route that returns HTML with a 200) are recorded in AGENTS.md.