### PR TITLE
Fix password login against Planka access tokens

### DIFF
--- a/crates/plnk-cli/src/commands/auth.rs
+++ b/crates/plnk-cli/src/commands/auth.rs
@@ -109,7 +109,17 @@ async fn do_login(
     })?;
 
     // Validate and show user identity
-    let user = validate_access_token_with_policy(&server, &token, transport_policy.clone()).await?;
+    // Planka deployments differ in how they accept access tokens on the
+    // authenticated API. Prefer the documented Bearer scheme, but fall back
+    // to the API-key header for older/self-hosted deployments.
+    let user = match validate_access_token_with_policy(&server, &token, transport_policy.clone())
+        .await
+    {
+        Ok(user) => user,
+        Err(bearer_error) => validate_token_with_policy(&server, &token, transport_policy.clone())
+            .await
+            .map_err(|_| bearer_error)?,
+    };
 
     if format == OutputFormat::Json {
         render_item(&user, format, false)?;

--- a/crates/plnk-cli/src/commands/auth.rs
+++ b/crates/plnk-cli/src/commands/auth.rs
@@ -1,6 +1,6 @@
 use plnk_core::auth::{
-    self, ConfigFile, delete_config, read_config, resolve_credentials, validate_token_with_policy,
-    write_config,
+    self, ConfigFile, delete_config, read_config, resolve_credentials,
+    validate_access_token_with_policy, validate_token_with_policy, write_config,
 };
 use plnk_core::error::PlankaError;
 use plnk_core::transport::TransportPolicy;
@@ -109,7 +109,7 @@ async fn do_login(
     })?;
 
     // Validate and show user identity
-    let user = validate_token_with_policy(&server, &token, transport_policy.clone()).await?;
+    let user = validate_access_token_with_policy(&server, &token, transport_policy.clone()).await?;
 
     if format == OutputFormat::Json {
         render_item(&user, format, false)?;

--- a/crates/plnk-cli/src/commands/auth.rs
+++ b/crates/plnk-cli/src/commands/auth.rs
@@ -1,5 +1,5 @@
 use plnk_core::auth::{
-    self, ConfigFile, delete_config, read_config, resolve_credentials,
+    self, AuthScheme, ConfigFile, delete_config, read_config, resolve_credentials,
     validate_access_token_with_policy, validate_token_with_policy, write_config,
 };
 use plnk_core::error::PlankaError;
@@ -105,6 +105,7 @@ async fn do_login(
     write_config(&ConfigFile {
         server: server_url,
         token: token.clone(),
+        auth_scheme: AuthScheme::Bearer,
         http: existing_http,
     })?;
 
@@ -155,6 +156,7 @@ fn do_token_set(
     write_config(&ConfigFile {
         server: server_url,
         token: token.to_string(),
+        auth_scheme: AuthScheme::ApiKey,
         http: existing_http,
     })?;
 
@@ -169,8 +171,16 @@ async fn do_whoami(
     transport_policy: &TransportPolicy,
 ) -> Result<(), PlankaError> {
     let creds = resolve_credentials(flag_server, flag_token)?;
-    let user =
-        validate_token_with_policy(&creds.server, &creds.token, transport_policy.clone()).await?;
+    let user = match creds.auth_scheme {
+        AuthScheme::Bearer => {
+            validate_access_token_with_policy(&creds.server, &creds.token, transport_policy.clone())
+                .await?
+        }
+        AuthScheme::ApiKey => {
+            validate_token_with_policy(&creds.server, &creds.token, transport_policy.clone())
+                .await?
+        }
+    };
     render_item(&user, format, false)?;
     Ok(())
 }
@@ -210,8 +220,15 @@ async fn do_status(
     };
 
     // Try validating the token
-    let valid =
-        validate_token_with_policy(&creds.server, &creds.token, transport_policy.clone()).await;
+    let valid = match creds.auth_scheme {
+        AuthScheme::Bearer => {
+            validate_access_token_with_policy(&creds.server, &creds.token, transport_policy.clone())
+                .await
+        }
+        AuthScheme::ApiKey => {
+            validate_token_with_policy(&creds.server, &creds.token, transport_policy.clone()).await
+        }
+    };
 
     if format == OutputFormat::Json {
         let (authenticated, user_name) = match &valid {

--- a/crates/plnk-cli/src/commands/init.rs
+++ b/crates/plnk-cli/src/commands/init.rs
@@ -57,6 +57,10 @@ pub fn execute(
     let new_config = ConfigFile {
         server,
         token,
+        auth_scheme: existing
+            .as_ref()
+            .map(|config| config.auth_scheme)
+            .unwrap_or_default(),
         http,
     };
 

--- a/crates/plnk-cli/src/main.rs
+++ b/crates/plnk-cli/src/main.rs
@@ -184,7 +184,14 @@ fn build_client(
     transport_policy: &TransportPolicy,
 ) -> Result<PlankaClientV1, PlankaError> {
     let creds = resolve_credentials(flag_server, flag_token)?;
-    let http = HttpClient::with_policy(creds.server, &creds.token, transport_policy.clone())?;
+    let http = match creds.auth_scheme {
+        plnk_core::auth::AuthScheme::Bearer => {
+            HttpClient::with_bearer_policy(creds.server, &creds.token, transport_policy.clone())?
+        }
+        plnk_core::auth::AuthScheme::ApiKey => {
+            HttpClient::with_policy(creds.server, &creds.token, transport_policy.clone())?
+        }
+    };
     Ok(PlankaClientV1::new(http))
 }
 

--- a/crates/plnk-core/src/auth/config.rs
+++ b/crates/plnk-core/src/auth/config.rs
@@ -16,6 +16,14 @@ pub struct HttpConfig {
     pub retry_max_delay_ms: Option<u64>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuthScheme {
+    #[default]
+    ApiKey,
+    Bearer,
+}
+
 /// Config file contents.
 ///
 /// Default location on every OS: `~/.config/plnk/config.toml`, honoring
@@ -26,8 +34,14 @@ pub struct HttpConfig {
 pub struct ConfigFile {
     pub server: String,
     pub token: String,
+    #[serde(default, skip_serializing_if = "is_default_auth_scheme")]
+    pub auth_scheme: AuthScheme,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http: Option<HttpConfig>,
+}
+
+fn is_default_auth_scheme(scheme: &AuthScheme) -> bool {
+    *scheme == AuthScheme::ApiKey
 }
 
 /// Resolve the config file path.
@@ -257,6 +271,7 @@ mod tests {
         let config = ConfigFile {
             server: "http://localhost:3000".to_string(),
             token: "test-token-123".to_string(),
+            auth_scheme: AuthScheme::ApiKey,
             http: Some(HttpConfig {
                 max_in_flight: Some(8),
                 rate_limit: Some(10),

--- a/crates/plnk-core/src/auth/login.rs
+++ b/crates/plnk-core/src/auth/login.rs
@@ -80,3 +80,14 @@ pub async fn validate_token_with_policy(
     let resp: UserMeResponse = client.get("/api/users/me").await?;
     Ok(resp.item)
 }
+
+/// Validate a Planka access token using the Bearer authentication scheme.
+pub async fn validate_access_token_with_policy(
+    server: &Url,
+    token: &str,
+    policy: TransportPolicy,
+) -> Result<User, PlankaError> {
+    let client = HttpClient::with_bearer_policy(server.clone(), token, policy)?;
+    let resp: UserMeResponse = client.get("/api/users/me").await?;
+    Ok(resp.item)
+}

--- a/crates/plnk-core/src/auth/login.rs
+++ b/crates/plnk-core/src/auth/login.rs
@@ -9,6 +9,7 @@ use crate::transport::TransportPolicy;
 /// Request body for `POST /api/access-tokens`.
 #[derive(Serialize)]
 struct LoginRequest<'a> {
+    #[serde(rename = "emailOrUsername")]
     email: &'a str,
     password: &'a str,
 }

--- a/crates/plnk-core/src/auth/mod.rs
+++ b/crates/plnk-core/src/auth/mod.rs
@@ -2,7 +2,10 @@ mod config;
 mod login;
 
 pub use config::{ConfigFile, HttpConfig, config_path, delete_config, read_config, write_config};
-pub use login::{login, login_with_policy, validate_token, validate_token_with_policy};
+pub use login::{
+    login, login_with_policy, validate_access_token_with_policy, validate_token,
+    validate_token_with_policy,
+};
 
 use tracing::debug;
 use url::Url;

--- a/crates/plnk-core/src/auth/mod.rs
+++ b/crates/plnk-core/src/auth/mod.rs
@@ -1,7 +1,9 @@
 mod config;
 mod login;
 
-pub use config::{ConfigFile, HttpConfig, config_path, delete_config, read_config, write_config};
+pub use config::{
+    AuthScheme, ConfigFile, HttpConfig, config_path, delete_config, read_config, write_config,
+};
 pub use login::{
     login, login_with_policy, validate_access_token_with_policy, validate_token,
     validate_token_with_policy,
@@ -17,6 +19,7 @@ use crate::error::PlankaError;
 pub struct ResolvedCredentials {
     pub server: Url,
     pub token: String,
+    pub auth_scheme: AuthScheme,
     pub source: CredentialSource,
 }
 
@@ -59,6 +62,7 @@ pub fn resolve_credentials(
         return Ok(ResolvedCredentials {
             server,
             token: token.to_string(),
+            auth_scheme: AuthScheme::ApiKey,
             source: CredentialSource::Flags,
         });
     }
@@ -84,6 +88,7 @@ pub fn resolve_credentials(
             return Ok(ResolvedCredentials {
                 server,
                 token: token.to_string(),
+                auth_scheme: AuthScheme::ApiKey,
                 source: CredentialSource::Environment,
             });
         }
@@ -99,6 +104,7 @@ pub fn resolve_credentials(
         return Ok(ResolvedCredentials {
             server,
             token: config.token,
+            auth_scheme: config.auth_scheme,
             source: CredentialSource::ConfigFile,
         });
     }

--- a/crates/plnk-core/src/client/mod.rs
+++ b/crates/plnk-core/src/client/mod.rs
@@ -40,7 +40,16 @@ impl HttpClient {
         api_key: &str,
         policy: TransportPolicy,
     ) -> Result<Self, PlankaError> {
-        Self::build(base_url, Some(api_key), policy)
+        Self::build(base_url, Some(api_key), false, policy)
+    }
+
+    /// Create an authenticated client using a Planka access token.
+    pub fn with_bearer_policy(
+        base_url: Url,
+        token: &str,
+        policy: TransportPolicy,
+    ) -> Result<Self, PlankaError> {
+        Self::build(base_url, Some(token), true, policy)
     }
 
     /// Create a new unauthenticated HTTP client with the default transport policy.
@@ -62,7 +71,7 @@ impl HttpClient {
         base_url: Url,
         policy: TransportPolicy,
     ) -> Result<Self, PlankaError> {
-        Self::build(base_url, None, policy)
+        Self::build(base_url, None, false, policy)
     }
 
     /// Access the shared transport policy for this client.
@@ -74,18 +83,27 @@ impl HttpClient {
     fn build(
         base_url: Url,
         api_key: Option<&str>,
+        bearer: bool,
         policy: TransportPolicy,
     ) -> Result<Self, PlankaError> {
         let mut headers = HeaderMap::new();
 
-        if let Some(api_key) = api_key {
+        if let Some(token) = api_key {
+            let value = if bearer {
+                format!("Bearer {token}")
+            } else {
+                token.to_string()
+            };
             let mut auth_value =
-                HeaderValue::from_str(api_key).map_err(|e| PlankaError::ApiError {
+                HeaderValue::from_str(&value).map_err(|e| PlankaError::ApiError {
                     status: 0,
-                    message: format!("Invalid API key format: {e}"),
+                    message: format!("Invalid authentication token format: {e}"),
                 })?;
             auth_value.set_sensitive(true);
-            headers.insert("X-API-Key", auth_value);
+            headers.insert(
+                if bearer { "Authorization" } else { "X-API-Key" },
+                auth_value,
+            );
         }
 
         let inner = Client::builder()

--- a/crates/plnk-core/src/client/mod.rs
+++ b/crates/plnk-core/src/client/mod.rs
@@ -1,4 +1,4 @@
-use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::{Client, RequestBuilder, StatusCode};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -18,6 +18,7 @@ use crate::transport::{TransportPolicy, TransportRuntime};
 pub struct HttpClient {
     inner: Client,
     base_url: Url,
+    auth_header: Option<(HeaderName, HeaderValue)>,
     transport: TransportRuntime,
 }
 
@@ -86,28 +87,8 @@ impl HttpClient {
         bearer: bool,
         policy: TransportPolicy,
     ) -> Result<Self, PlankaError> {
-        let mut headers = HeaderMap::new();
-
-        if let Some(token) = api_key {
-            let value = if bearer {
-                format!("Bearer {token}")
-            } else {
-                token.to_string()
-            };
-            let mut auth_value =
-                HeaderValue::from_str(&value).map_err(|e| PlankaError::ApiError {
-                    status: 0,
-                    message: format!("Invalid authentication token format: {e}"),
-                })?;
-            auth_value.set_sensitive(true);
-            headers.insert(
-                if bearer { "Authorization" } else { "X-API-Key" },
-                auth_value,
-            );
-        }
-
         let inner = Client::builder()
-            .default_headers(headers)
+            .default_headers(HeaderMap::new())
             .user_agent(format!("plnk/{}", env!("CARGO_PKG_VERSION")))
             .timeout(std::time::Duration::from_secs(30))
             .build()
@@ -117,10 +98,15 @@ impl HttpClient {
             })?;
 
         let transport = TransportRuntime::new(policy)?;
+        let auth_header = match api_key {
+            Some(token) => Some(auth_header_value(token, bearer)?),
+            None => None,
+        };
 
         Ok(Self {
             inner,
             base_url,
+            auth_header,
             transport,
         })
     }
@@ -134,8 +120,12 @@ impl HttpClient {
         &self,
         method: &str,
         path: &str,
-        request: RequestBuilder,
+        mut request: RequestBuilder,
     ) -> Result<reqwest::Response, PlankaError> {
+        if let Some((name, value)) = &self.auth_header {
+            request = request.header(name.clone(), value.clone());
+        }
+
         let retry_attempts = self.transport.policy().retry_attempts;
         let retryable_method =
             retry_attempts > 0 && self.transport.retries_allowed_for_method(method);
@@ -365,4 +355,23 @@ impl HttpClient {
             },
         }
     }
+}
+
+fn auth_header_value(token: &str, bearer: bool) -> Result<(HeaderName, HeaderValue), PlankaError> {
+    let name = if bearer {
+        reqwest::header::AUTHORIZATION
+    } else {
+        HeaderName::from_static("x-api-key")
+    };
+    let value = if bearer {
+        format!("Bearer {token}")
+    } else {
+        token.to_string()
+    };
+    let mut header_value = HeaderValue::from_str(&value).map_err(|e| PlankaError::ApiError {
+        status: 0,
+        message: format!("Invalid authentication token format: {e}"),
+    })?;
+    header_value.set_sensitive(true);
+    Ok((name, header_value))
 }

--- a/crates/plnk-core/tests/auth_login.rs
+++ b/crates/plnk-core/tests/auth_login.rs
@@ -10,7 +10,7 @@ async fn login_success() {
     Mock::given(method("POST"))
         .and(path("/api/access-tokens"))
         .and(body_json(serde_json::json!({
-            "email": "test@example.com",
+            "emailOrUsername": "test@example.com",
             "password": "secret123"
         })))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({


### PR DESCRIPTION
## Problem

`plnk auth login` failed against current Planka in two ways:

1. The login request sent `email`, but Planka expects `emailOrUsername`. That produced HTTP 400.
2. After login, Planka returns an access token that must be sent as `Authorization: Bearer`. `plnk` treated every stored token as an API key and sent `X-API-Key`, which produced `Access token is missing, invalid or expired`.

API keys still use `X-API-Key`. Password-login tokens do not.

## Change

- Serialize the login identifier as `emailOrUsername`.
- Persist `auth_scheme` in `~/.config/plnk/config.toml`:
  - `bearer` after `plnk auth login`
  - `api-key` after `plnk auth token set` / flags / env
- Attach the matching header on every HTTP request, not just during login validation.
- Keep existing API-key auth working for `PLANKA_TOKEN`, `--token`, and `plnk init`.

## Verification

- `cargo test -p plnk-core --test auth_login`
- Rebuilt `plnk` from this branch and confirmed `plnk auth login` succeeds against a self-hosted Planka instance, then `plnk auth status` / `plnk auth whoami` resolve the logged-in user.